### PR TITLE
feat(tracking): add POI-literature metrics & consolidate metric computation

### DIFF
--- a/pipelines/compute_records.pipe.py
+++ b/pipelines/compute_records.pipe.py
@@ -1,0 +1,108 @@
+"""Standalone pipeline to compute/recompute best_record.json for result directories.
+
+Usage:
+    # Compute records for a specific engine+state
+    python pipelines/compute_records.pipe.py --engine hgi --state alabama
+
+    # Compute records for all engine+state combos found under results/
+    python pipelines/compute_records.pipe.py --all
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+_src = str(Path(__file__).resolve().parent.parent / "src")
+if _src not in sys.path:
+    sys.path.insert(0, _src)
+
+from configs.paths import RESULTS_ROOT, EmbeddingEngine, IoPaths
+from tracking.records import compute_best_record, scan_previous_bests
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+_VALID_ENGINES = [e.value for e in EmbeddingEngine]
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compute best_record.json for training result directories.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--engine",
+        type=str,
+        default=None,
+        choices=_VALID_ENGINES,
+        help="Embedding engine.",
+    )
+    parser.add_argument(
+        "--state",
+        type=str,
+        default=None,
+        help="Dataset state (e.g. florida, alabama).",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Compute records for all engine+state directories found under results/.",
+    )
+    return parser.parse_args(argv)
+
+
+def _process_dir(results_dir: Path, label: str) -> None:
+    """Compute best_record.json for a single results directory."""
+    bests = scan_previous_bests(results_dir)
+    if not bests:
+        logger.info("  %s: no runs found, skipping.", label)
+        return
+
+    record_path = compute_best_record(results_dir)
+    logger.info("  %s: wrote %s", label, record_path)
+    for task, (f1, folder) in sorted(bests.items()):
+        logger.info("    %s: F1=%.4f (%s)", task, f1, folder)
+
+
+def main(argv=None) -> None:
+    args = _parse_args(argv)
+
+    if args.all:
+        if not RESULTS_ROOT.exists():
+            logger.error("Results root not found: %s", RESULTS_ROOT)
+            sys.exit(1)
+
+        count = 0
+        for engine_dir in sorted(RESULTS_ROOT.iterdir()):
+            if not engine_dir.is_dir():
+                continue
+            for state_dir in sorted(engine_dir.iterdir()):
+                if not state_dir.is_dir():
+                    continue
+                label = f"{engine_dir.name}/{state_dir.name}"
+                _process_dir(state_dir, label)
+                count += 1
+
+        logger.info("Processed %d engine+state directories.", count)
+
+    elif args.engine is not None and args.state is not None:
+        engine = EmbeddingEngine(args.engine)
+        results_dir = IoPaths.get_results_dir(args.state, engine)
+        if not results_dir.exists():
+            logger.error("Results directory not found: %s", results_dir)
+            sys.exit(1)
+        label = f"{args.engine}/{args.state}"
+        _process_dir(results_dir, label)
+
+    else:
+        logger.error("Provide --engine and --state, or use --all.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipelines/compute_records.pipe.py
+++ b/pipelines/compute_records.pipe.py
@@ -19,7 +19,7 @@ if _src not in sys.path:
     sys.path.insert(0, _src)
 
 from configs.paths import RESULTS_ROOT, EmbeddingEngine, IoPaths
-from tracking.records import compute_best_record, scan_previous_bests
+from tracking.records import compute_best_record
 
 logging.basicConfig(
     level=logging.INFO,
@@ -58,15 +58,18 @@ def _parse_args(argv=None) -> argparse.Namespace:
 
 def _process_dir(results_dir: Path, label: str) -> None:
     """Compute best_record.json for a single results directory."""
-    bests = scan_previous_bests(results_dir)
-    if not bests:
+    # Check if any runs exist before writing.
+    if not list(results_dir.glob("*/summary/full_summary.json")):
         logger.info("  %s: no runs found, skipping.", label)
         return
 
     record_path = compute_best_record(results_dir)
     logger.info("  %s: wrote %s", label, record_path)
-    for task, (f1, folder) in sorted(bests.items()):
-        logger.info("    %s: F1=%.4f (%s)", task, f1, folder)
+
+    import json
+    data = json.loads(record_path.read_text(encoding="utf-8"))
+    for task, info in sorted(data.get("tasks", {}).items()):
+        logger.info("    %s: F1=%.4f (%s)", task, info["f1_mean"], info["run_folder"])
 
 
 def main(argv=None) -> None:

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -21,6 +21,7 @@ if _src not in sys.path:
 from configs.experiment import ExperimentConfig
 from configs.paths import EmbeddingEngine, IoPaths
 from data.folds import FoldCreator, TaskType
+from tracking.metrics import compute_classification_metrics
 from training.evaluate import collect_predictions, build_report
 
 import torch
@@ -144,8 +145,6 @@ def main(argv=None) -> None:
     logger.info("Loaded checkpoint: %s", checkpoint_path)
 
     # Evaluate
-    from tracking.metrics import compute_classification_metrics
-
     num_classes = config.model_params.get("num_classes", 7)
 
     def _log_metrics(label: str, logits, targets_np):

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -144,6 +144,21 @@ def main(argv=None) -> None:
     logger.info("Loaded checkpoint: %s", checkpoint_path)
 
     # Evaluate
+    from tracking.metrics import compute_classification_metrics
+
+    num_classes = config.model_params.get("num_classes", 7)
+
+    def _log_metrics(label: str, logits, targets_np):
+        targets_t = torch.as_tensor(targets_np)
+        metrics = compute_classification_metrics(
+            logits, targets_t, num_classes=num_classes,
+        )
+        logger.info(
+            "%s metrics: %s",
+            label,
+            {k: round(v, 4) for k, v in metrics.items()},
+        )
+
     if task == "mtl":
         # MTLnet exposes per-head entry points (cat_forward / next_forward)
         # that run only the relevant subgraph — no dummy zero tensors, no
@@ -151,11 +166,11 @@ def main(argv=None) -> None:
         # heads are independent is now expressed on the model class itself
         # instead of being implicit in eval helper code. See
         # src/models/mtlnet.py:cat_forward / next_forward.
-        cat_preds, cat_targets = collect_predictions(
+        cat_preds, cat_targets, cat_logits = collect_predictions(
             model, fold.category.val.dataloader, DEVICE,
             forward_fn=lambda m, x: m.cat_forward(x),
         )
-        next_preds, next_targets = collect_predictions(
+        next_preds, next_targets, next_logits = collect_predictions(
             model, fold.next.val.dataloader, DEVICE,
             forward_fn=lambda m, x: m.next_forward(x),
         )
@@ -165,21 +180,24 @@ def main(argv=None) -> None:
             "Evaluation report (fold %d, task=mtl, head=category):\n%s",
             args.fold, cat_report,
         )
+        _log_metrics("category", cat_logits, cat_targets)
         logger.info(
             "Evaluation report (fold %d, task=mtl, head=next):\n%s",
             args.fold, next_report,
         )
+        _log_metrics("next", next_logits, next_targets)
         return
 
     if task == "category":
         loader = fold.category.val.dataloader
-        preds, targets = collect_predictions(model, loader, DEVICE)
+        preds, targets, logits = collect_predictions(model, loader, DEVICE)
     else:
         loader = fold.next.val.dataloader
-        preds, targets = collect_predictions(model, loader, DEVICE)
+        preds, targets, logits = collect_predictions(model, loader, DEVICE)
 
     report = build_report(preds, targets)
     logger.info("Evaluation report (fold %d, task=%s):\n%s", args.fold, task, report)
+    _log_metrics(task, logits, targets)
 
 
 if __name__ == "__main__":

--- a/src/tracking/display.py
+++ b/src/tracking/display.py
@@ -39,15 +39,22 @@ class ClassColorFormatter(logging.Formatter):
 class HistoryDisplay:
     LOGGER_NAME = "ml.history.display"
 
+    # Headline metric names shown in the end-of-fold summary table, in
+    # display order. Override via constructor to surface extra metrics
+    # (e.g. ``top3_acc``, ``f1_weighted``) in the terminal output.
+    DEFAULT_HEADLINE_METRICS = ("f1", "accuracy")
+
     def __init__(
         self,
         history: "MLHistory",
         label_map: Optional[Dict[int, str]] = None,
         show_report: bool = False,
+        headline_metrics: Optional[Sequence[str]] = None,
     ):
         self.h = history
         self.label_map = label_map or {}
         self.show_report = show_report
+        self.headline_metrics = tuple(headline_metrics) if headline_metrics else self.DEFAULT_HEADLINE_METRICS
         self.log = logging.getLogger(self.LOGGER_NAME)
 
         if not any(isinstance(h, logging.StreamHandler) for h in self.log.handlers):
@@ -111,19 +118,19 @@ class HistoryDisplay:
             f"Total: {self._format_time(elapsed)} | Remaining: {self._format_time(remaining)}"
         )
         self.log.info(self._sep(f"Summary Fold {idx + 1}", width=60, sep='-'))
-        self.log.info(
-            f"{'Task':<10} | {'Best Epoch':<10} | {'Accuracy':<9} | {'F1 Score':<9} |"
-        )
+        header_cells = [f"{'Task':<10}", f"{'Best Epoch':<10}"]
+        for metric in self.headline_metrics:
+            header_cells.append(f"{metric.replace('_', ' ').title():<10}")
+        self.log.info(" | ".join(header_cells) + " |")
         for t in self.h.tasks:
             th = self.h.folds[idx].task(t)
             be = th.best.best_epoch
-            acc_vals = th.val.get('accuracy')
-            f1_vals = th.val.get('f1')
-            acc = acc_vals[be] if acc_vals and be >= 0 and be < len(acc_vals) else 0.0
-            f1 = f1_vals[be] if f1_vals and be >= 0 and be < len(f1_vals) else 0.0
-            self.log.info(
-                f"{t:<10} | {be:^10d} | {acc * 100:>7.2f}%  | {f1 * 100:>7.2f}%  |"
-            )
+            row = [f"{t:<10}", f"{be:^10d}"]
+            for metric in self.headline_metrics:
+                vals = th.val.get(metric)
+                v = vals[be] if vals and be >= 0 and be < len(vals) else 0.0
+                row.append(f"{v * 100:>8.2f}% ")
+            self.log.info(" | ".join(row) + " |")
 
         if self.show_report:
             for t in self.h.tasks:

--- a/src/tracking/display.py
+++ b/src/tracking/display.py
@@ -42,7 +42,7 @@ class HistoryDisplay:
     # Headline metric names shown in the end-of-fold summary table, in
     # display order. Override via constructor to surface extra metrics
     # (e.g. ``top3_acc``, ``f1_weighted``) in the terminal output.
-    DEFAULT_HEADLINE_METRICS = ("f1", "accuracy")
+    DEFAULT_HEADLINE_METRICS = ("f1", "accuracy", "top3_acc")
 
     def __init__(
         self,

--- a/src/tracking/display.py
+++ b/src/tracking/display.py
@@ -170,6 +170,65 @@ class HistoryDisplay:
                 f"{'macro avg':<12} | {p_str} | {r_str} | {f_str} | {'':>10}"
             )
 
+    def _collect_best_epoch_metrics(self) -> Dict[str, Dict[str, list]]:
+        """Collect headline metric values at each fold's best epoch, per task.
+
+        Returns ``{task: {metric_name: [val_fold0, val_fold1, ...]}}``.
+        """
+        result: Dict[str, Dict[str, list]] = {}
+        for fold in self.h.folds:
+            for task in self.h.tasks:
+                th = fold.tasks.get(task)
+                if not th:
+                    continue
+                be = th.best.best_epoch
+                if be < 0:
+                    continue
+                task_dict = result.setdefault(task, {})
+                for metric in self.headline_metrics:
+                    vals = th.val.get(metric)
+                    if vals and be < len(vals):
+                        task_dict.setdefault(metric, []).append(vals[be])
+        return result
+
+    def _display_final_results(self) -> None:
+        """Print a compact "Final Results" table across all folds.
+
+        Always shown — this is the first thing a researcher looks at after a
+        run finishes. For N > 1 folds, values are ``mean +- stdev``.
+        """
+        perf = self._collect_best_epoch_metrics()
+        if not perf:
+            return
+
+        n_folds = self.h.num_folds
+        title = f"Final Results ({n_folds} fold{'s' if n_folds > 1 else ''})"
+        self.log.info(self._sep(title, width=60, sep='-'))
+
+        # Decide column width: "mean +- std" needs more room than a bare value.
+        col_val = 18 if n_folds > 1 else 10
+        col_task = 10
+        header = [f"{'Task':<{col_task}}"]
+        for m in self.headline_metrics:
+            header.append(f"{m.replace('_', ' ').title():<{col_val}}")
+        self.log.info(" | ".join(header) + " |")
+
+        for task in self.h.tasks:
+            task_metrics = perf.get(task, {})
+            row = [f"{task:<{col_task}}"]
+            for m in self.headline_metrics:
+                values = task_metrics.get(m, [])
+                if not values:
+                    row.append(f"{'N/A':>{col_val}}")
+                elif n_folds > 1:
+                    avg = mean(values) * 100
+                    std = _safe_stdev(values) * 100
+                    cell = f"{avg:.2f} ± {std:.2f}%"
+                    row.append(f"{cell:>{col_val}}")
+                else:
+                    row.append(f"{values[0] * 100:>{col_val - 1}.2f}%")
+            self.log.info(" | ".join(row) + " |")
+
     def end_training(self):
         self.log.info(self._sep("Training Complete"))
         self.log.info(self._sep("Summary", width=60, sep='-'))
@@ -185,6 +244,10 @@ class HistoryDisplay:
                 f"N. Epochs: {self.h.model_parms.num_epochs} | "
                 f"Batch Size: {self.h.model_parms.batch_size}"
             )
+
+        # Always show the compact aggregate results table — this is the
+        # first thing a researcher cares about after a training run.
+        self._display_final_results()
 
         if self.show_report:
             for task in self.h.tasks:

--- a/src/tracking/display.py
+++ b/src/tracking/display.py
@@ -2,7 +2,6 @@ import logging
 from statistics import mean, stdev
 from typing import Dict, Optional, Sequence, TYPE_CHECKING
 
-
 def _safe_stdev(xs: Sequence[float]) -> float:
     """stdev() that returns 0.0 for a single data point instead of raising.
 
@@ -16,6 +15,7 @@ def _safe_stdev(xs: Sequence[float]) -> float:
 
 if TYPE_CHECKING:
     from tracking.experiment import MLHistory
+    from tracking.records import RecordComparison
 
 logging.basicConfig(
     level=logging.INFO,
@@ -305,6 +305,39 @@ class HistoryDisplay:
                 self.display_report(final_report)
 
         self.log.info(self._sep("End of all folds", width=60))
+
+    def display_records(self, comparison: "RecordComparison") -> None:
+        """Show per-task record comparison after training ends."""
+        if not comparison.tasks:
+            return
+
+        self.log.info(self._sep("Record Comparison", width=60, sep="-"))
+
+        for tr in comparison.tasks:
+            f1_pct = tr.current_f1 * 100
+            if tr.previous_best_run == "":
+                # First run ever for this task in this engine+state.
+                self.log.info(
+                    f"  {tr.task:<12} F1: {f1_pct:6.2f}%  |  "
+                    f"First run - baseline established"
+                )
+            elif tr.is_new_record:
+                prev_pct = tr.previous_best_f1 * 100
+                self.log.info(
+                    f"  {tr.task:<12} F1: {f1_pct:6.2f}%  |  "
+                    f"NEW RECORD  (prev: {prev_pct:.2f}%)"
+                )
+            else:
+                prev_pct = tr.previous_best_f1 * 100
+                run_short = tr.previous_best_run[:35]
+                if len(tr.previous_best_run) > 35:
+                    run_short += "..."
+                self.log.info(
+                    f"  {tr.task:<12} F1: {f1_pct:6.2f}%  |  "
+                    f"Previous best: {prev_pct:.2f}% ({run_short})"
+                )
+
+        self.log.info(self._sep("", width=60, sep="-"))
 
     def flops(self):
         if self.h.flops:

--- a/src/tracking/display.py
+++ b/src/tracking/display.py
@@ -2,6 +2,7 @@ import logging
 from statistics import mean, stdev
 from typing import Dict, Optional, Sequence, TYPE_CHECKING
 
+
 def _safe_stdev(xs: Sequence[float]) -> float:
     """stdev() that returns 0.0 for a single data point instead of raising.
 
@@ -88,6 +89,17 @@ class HistoryDisplay:
             return f"{seconds:.2f}s"
         minutes = seconds / 60
         return f"{minutes:.2f}m"
+
+    @staticmethod
+    def _format_si(value: float) -> str:
+        """Format a number with K/M/G SI suffix."""
+        if value >= 1e9:
+            return f"{value / 1e9:.2f}G"
+        if value >= 1e6:
+            return f"{value / 1e6:.2f}M"
+        if value >= 1e3:
+            return f"{value / 1e3:.2f}K"
+        return f"{value:.0f}"
 
     def _format_metric(self, value, is_percentage: bool = True, width: int = 8) -> str:
         if isinstance(value, (int, float)):
@@ -257,21 +269,9 @@ class HistoryDisplay:
             flops_val = self.h.flops.flops
             params_val = self.h.flops.params
             if isinstance(flops_val, (int, float)) and flops_val > 0:
-                if flops_val >= 1e9:
-                    stats_parts.append(f"FLOPs: {flops_val / 1e9:.2f}G")
-                elif flops_val >= 1e6:
-                    stats_parts.append(f"FLOPs: {flops_val / 1e6:.2f}M")
-                elif flops_val >= 1e3:
-                    stats_parts.append(f"FLOPs: {flops_val / 1e3:.2f}K")
-                else:
-                    stats_parts.append(f"FLOPs: {flops_val}")
+                stats_parts.append(f"FLOPs: {self._format_si(flops_val)}")
             if isinstance(params_val, (int, float)) and params_val > 0:
-                if params_val >= 1e6:
-                    stats_parts.append(f"Params: {params_val / 1e6:.2f}M")
-                elif params_val >= 1e3:
-                    stats_parts.append(f"Params: {params_val / 1e3:.2f}K")
-                else:
-                    stats_parts.append(f"Params: {params_val}")
+                stats_parts.append(f"Params: {self._format_si(params_val)}")
         self.log.info(" | ".join(stats_parts))
 
         if self.show_report:
@@ -337,7 +337,7 @@ class HistoryDisplay:
                     f"Previous best: {prev_pct:.2f}% ({run_short})"
                 )
 
-        self.log.info(self._sep("", width=60, sep="-"))
+        self.log.info("-" * 60)
 
     def flops(self):
         if self.h.flops:

--- a/src/tracking/display.py
+++ b/src/tracking/display.py
@@ -249,6 +249,31 @@ class HistoryDisplay:
         # first thing a researcher cares about after a training run.
         self._display_final_results()
 
+        # Execution stats below the metric table — total wall time + model
+        # complexity so runs are easy to compare at a glance.
+        duration = self.h.timer.get_duration() if hasattr(self.h.timer, 'get_duration') else 0
+        stats_parts = [f"Total Time: {self._format_time(duration)}"]
+        if self.h.flops:
+            flops_val = self.h.flops.flops
+            params_val = self.h.flops.params
+            if isinstance(flops_val, (int, float)) and flops_val > 0:
+                if flops_val >= 1e9:
+                    stats_parts.append(f"FLOPs: {flops_val / 1e9:.2f}G")
+                elif flops_val >= 1e6:
+                    stats_parts.append(f"FLOPs: {flops_val / 1e6:.2f}M")
+                elif flops_val >= 1e3:
+                    stats_parts.append(f"FLOPs: {flops_val / 1e3:.2f}K")
+                else:
+                    stats_parts.append(f"FLOPs: {flops_val}")
+            if isinstance(params_val, (int, float)) and params_val > 0:
+                if params_val >= 1e6:
+                    stats_parts.append(f"Params: {params_val / 1e6:.2f}M")
+                elif params_val >= 1e3:
+                    stats_parts.append(f"Params: {params_val / 1e3:.2f}K")
+                else:
+                    stats_parts.append(f"Params: {params_val}")
+        self.log.info(" | ".join(stats_parts))
+
         if self.show_report:
             for task in self.h.tasks:
                 self.log.info(self._sep(f"Avg. Task: {task}", width=60, sep='-'))

--- a/src/tracking/display.py
+++ b/src/tracking/display.py
@@ -118,18 +118,22 @@ class HistoryDisplay:
             f"Total: {self._format_time(elapsed)} | Remaining: {self._format_time(remaining)}"
         )
         self.log.info(self._sep(f"Summary Fold {idx + 1}", width=60, sep='-'))
-        header_cells = [f"{'Task':<10}", f"{'Best Epoch':<10}"]
+        # Column widths are unified at 10 chars so header and row cells
+        # line up regardless of how many headline metrics are configured.
+        col = 10
+        header_cells = [f"{'Task':<{col}}", f"{'Best Epoch':<{col}}"]
         for metric in self.headline_metrics:
-            header_cells.append(f"{metric.replace('_', ' ').title():<10}")
+            header_cells.append(f"{metric.replace('_', ' ').title():<{col}}")
         self.log.info(" | ".join(header_cells) + " |")
         for t in self.h.tasks:
             th = self.h.folds[idx].task(t)
             be = th.best.best_epoch
-            row = [f"{t:<10}", f"{be:^10d}"]
+            row = [f"{t:<{col}}", f"{be:^{col}d}"]
             for metric in self.headline_metrics:
                 vals = th.val.get(metric)
                 v = vals[be] if vals and be >= 0 and be < len(vals) else 0.0
-                row.append(f"{v * 100:>8.2f}% ")
+                # Reserve one char for '%', leave col-1 for the number.
+                row.append(f"{v * 100:>{col - 1}.2f}%")
             self.log.info(" | ".join(row) + " |")
 
         if self.show_report:

--- a/src/tracking/experiment.py
+++ b/src/tracking/experiment.py
@@ -128,7 +128,8 @@ class MLHistory:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.end()
         if exc_type is None and self._save_path is not None:
-            self.storage.save(path=self._save_path, label_map=self._label_map)
+            run_path = self.storage.save(path=self._save_path, label_map=self._label_map)
+            self._compare_and_save_records(run_path)
 
     # --- Iterator ---
 
@@ -208,6 +209,27 @@ class MLHistory:
                 "num_folds": self.num_folds,
                 "tasks": list(self.tasks),
             })
+
+    def _compare_and_save_records(self, run_path: Path) -> None:
+        """Compare the current run against historical bests and display/save records."""
+        summary_path = run_path / "summary" / "full_summary.json"
+        if not summary_path.exists():
+            return
+        try:
+            import json
+            from tracking.records import compare_records, save_best_record
+
+            current_summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            comparison = compare_records(self._save_path, current_summary, run_path.name)
+            self.display.display_records(comparison)
+            save_best_record(
+                self._save_path, comparison, current_summary, run_path.name,
+            )
+        except Exception as exc:
+            import logging
+            logging.getLogger(__name__).warning(
+                "Record comparison failed: %s", exc,
+            )
 
     def end(self):
         if self._ended:

--- a/src/tracking/experiment.py
+++ b/src/tracking/experiment.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import logging
 import time
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Union
@@ -216,17 +218,16 @@ class MLHistory:
         if not summary_path.exists():
             return
         try:
-            import json
             from tracking.records import compare_records, save_best_record
 
             current_summary = json.loads(summary_path.read_text(encoding="utf-8"))
             comparison = compare_records(self._save_path, current_summary, run_path.name)
-            self.display.display_records(comparison)
+            if self._verbose:
+                self.display.display_records(comparison)
             save_best_record(
                 self._save_path, comparison, current_summary, run_path.name,
             )
         except Exception as exc:
-            import logging
             logging.getLogger(__name__).warning(
                 "Record comparison failed: %s", exc,
             )

--- a/src/tracking/metrics.py
+++ b/src/tracking/metrics.py
@@ -1,0 +1,173 @@
+"""Classification metric computation for POI tasks.
+
+A single pure function converts a batch of logits + targets into a flat dict
+of scalar Python floats. The dict keys are stable names (optionally prefixed)
+that downstream ``MetricStore.log(**kwargs)`` calls can consume directly.
+
+Metric choices are grounded in ``docs/LITERATURE_SURVEY_POI_METRICS.md`` and
+``docs/POI_RELATED_WORK_METRICS.md``:
+
+  * ``accuracy`` (micro) and ``f1`` (macro) — unchanged primary metrics.
+  * ``accuracy_macro`` — balanced accuracy, complements micro under imbalance.
+  * ``f1_weighted`` — robustness-to-imbalance secondary signal.
+  * ``top{k}_acc`` for k in ``top_k`` — bridge to the next-POI recommendation
+    literature (Acc@K / Recall@K in the single-label case).
+  * ``mrr`` — mean reciprocal rank over the full class ranking.
+  * ``ndcg_{k}`` — NDCG@K with binary single-item relevance (reduces to the
+    well-defined single-label form used by ranking papers).
+
+The ``'f1'`` key stays identical to the previous
+``multiclass_f1_score(..., average='macro')`` value so existing
+``BestModelTracker(monitor='f1')`` behaviour is byte-identical.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, Iterable, Tuple
+
+import torch
+from torchmetrics.functional.classification import (
+    multiclass_accuracy,
+    multiclass_f1_score,
+)
+
+
+def _top_k_accuracy(logits: torch.Tensor, targets: torch.Tensor, k: int) -> float:
+    """Fraction of samples whose true class is in the top-k predictions."""
+    if k <= 1:
+        preds = logits.argmax(dim=-1)
+        return (preds == targets).float().mean().item()
+    k_eff = min(k, logits.shape[-1])
+    top_k = logits.topk(k_eff, dim=-1).indices  # (N, k_eff)
+    hit = (top_k == targets.unsqueeze(-1)).any(dim=-1)
+    return hit.float().mean().item()
+
+
+def _rank_of_target(logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+    """1-indexed rank of the true class in each row's descending sort.
+
+    Uses ``argsort`` rather than ``multiclass_accuracy(top_k=...)`` because we
+    want the actual rank, not a thresholded hit. Ties are broken by the
+    underlying sort stability (same contract as ``torch.argsort``).
+    """
+    order = logits.argsort(dim=-1, descending=True)         # (N, C)
+    matches = (order == targets.unsqueeze(-1)).int()         # (N, C)
+    rank_zero_indexed = matches.argmax(dim=-1)               # (N,)
+    return rank_zero_indexed + 1                              # 1-indexed
+
+
+def _mean_reciprocal_rank(logits: torch.Tensor, targets: torch.Tensor) -> float:
+    rank = _rank_of_target(logits, targets).float()
+    return (1.0 / rank).mean().item()
+
+
+def _ndcg_at_k(logits: torch.Tensor, targets: torch.Tensor, k: int) -> float:
+    """NDCG@K with single-relevant-item binary relevance.
+
+    IDCG is 1 (one relevant item, perfectly ranked). DCG is
+    ``1 / log2(rank + 1)`` if the true class falls in the top-k, else 0.
+    """
+    rank = _rank_of_target(logits, targets)                  # (N,)
+    hit = rank <= k
+    # Use float math; add 1 so rank=1 -> log2(2) = 1 -> DCG=1.
+    dcg = torch.where(
+        hit,
+        1.0 / torch.log2(rank.float() + 1.0),
+        torch.zeros_like(rank, dtype=torch.float32),
+    )
+    return dcg.mean().item()
+
+
+def compute_classification_metrics(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    num_classes: int,
+    top_k: Iterable[int] = (3, 5),
+    prefix: str = "",
+) -> Dict[str, float]:
+    """Compute every classification/ranking metric we track, in one pass.
+
+    Args:
+        logits: ``(N, C)`` float tensor. May live on CPU, CUDA or MPS.
+        targets: ``(N,)`` int tensor of class indices.
+        num_classes: Number of classes ``C``. Required by torchmetrics.
+        top_k: K values to report Top-K accuracy and NDCG@K for. ``k=1`` is
+            skipped because it would duplicate ``accuracy``.
+        prefix: Optional key prefix (e.g. ``"val_"``). Applied to every
+            returned key.
+
+    Returns:
+        ``dict[str, float]``: every value is a plain Python float, safe to
+        pass straight into ``MetricStore.log(**kwargs)``.
+
+    Edge cases:
+        * Empty batch (``N == 0``): returns all zeros. Callers should guard
+          against this upstream, but we handle it defensively so tests with
+          degenerate loaders don't crash.
+    """
+    if logits.ndim != 2:
+        raise ValueError(f"logits must be 2-D (N, C); got shape {tuple(logits.shape)}")
+    if targets.ndim != 1:
+        raise ValueError(f"targets must be 1-D (N,); got shape {tuple(targets.shape)}")
+    if logits.shape[0] != targets.shape[0]:
+        raise ValueError(
+            f"logits N={logits.shape[0]} != targets N={targets.shape[0]}"
+        )
+
+    def _key(name: str) -> str:
+        return f"{prefix}{name}"
+
+    # Degenerate batch — return zeros for every key we would have produced.
+    if logits.shape[0] == 0:
+        out: Dict[str, float] = {
+            _key("accuracy"): 0.0,
+            _key("accuracy_macro"): 0.0,
+            _key("f1"): 0.0,
+            _key("f1_weighted"): 0.0,
+            _key("mrr"): 0.0,
+        }
+        for k in top_k:
+            if k > 1:
+                out[_key(f"top{k}_acc")] = 0.0
+                out[_key(f"ndcg_{k}")] = 0.0
+        return out
+
+    # Targets and logits must share a device for torchmetrics / torch ops.
+    if targets.device != logits.device:
+        targets = targets.to(logits.device)
+
+    # torchmetrics expects integer predictions for the top-1 path.
+    preds = logits.argmax(dim=-1)
+
+    acc_micro = multiclass_accuracy(
+        preds, targets, num_classes=num_classes, average="micro"
+    ).item()
+    acc_macro = multiclass_accuracy(
+        preds, targets, num_classes=num_classes, average="macro"
+    ).item()
+    f1_macro = multiclass_f1_score(
+        preds, targets, num_classes=num_classes, average="macro", zero_division=0
+    ).item()
+    f1_weighted = multiclass_f1_score(
+        preds, targets, num_classes=num_classes, average="weighted", zero_division=0
+    ).item()
+
+    metrics: Dict[str, float] = {
+        _key("accuracy"): acc_micro,
+        _key("accuracy_macro"): acc_macro,
+        _key("f1"): f1_macro,
+        _key("f1_weighted"): f1_weighted,
+        _key("mrr"): _mean_reciprocal_rank(logits, targets),
+    }
+
+    for k in top_k:
+        if k <= 1:
+            continue
+        metrics[_key(f"top{k}_acc")] = _top_k_accuracy(logits, targets, k)
+        metrics[_key(f"ndcg_{k}")] = _ndcg_at_k(logits, targets, k)
+
+    return metrics
+
+
+__all__ = ["compute_classification_metrics"]

--- a/src/tracking/metrics.py
+++ b/src/tracking/metrics.py
@@ -23,8 +23,7 @@ The ``'f1'`` key stays identical to the previous
 
 from __future__ import annotations
 
-import math
-from typing import Dict, Iterable, Tuple
+from typing import Dict, Iterable
 
 import torch
 from torchmetrics.functional.classification import (
@@ -34,10 +33,11 @@ from torchmetrics.functional.classification import (
 
 
 def _top_k_accuracy(logits: torch.Tensor, targets: torch.Tensor, k: int) -> float:
-    """Fraction of samples whose true class is in the top-k predictions."""
-    if k <= 1:
-        preds = logits.argmax(dim=-1)
-        return (preds == targets).float().mean().item()
+    """Fraction of samples whose true class is in the top-k predictions.
+
+    Caller must pass ``k >= 2`` — the main API skips ``k == 1`` since that
+    would duplicate ``accuracy``.
+    """
     k_eff = min(k, logits.shape[-1])
     top_k = logits.topk(k_eff, dim=-1).indices  # (N, k_eff)
     hit = (top_k == targets.unsqueeze(-1)).any(dim=-1)
@@ -45,16 +45,22 @@ def _top_k_accuracy(logits: torch.Tensor, targets: torch.Tensor, k: int) -> floa
 
 
 def _rank_of_target(logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
-    """1-indexed rank of the true class in each row's descending sort.
+    """1-indexed "best-case" rank of the true class in each row.
 
-    Uses ``argsort`` rather than ``multiclass_accuracy(top_k=...)`` because we
-    want the actual rank, not a thresholded hit. Ties are broken by the
-    underlying sort stability (same contract as ``torch.argsort``).
+    Computed as ``1 + #{classes with a strictly higher logit than the target}``.
+    This is the canonical tie-handling for ranking metrics: if two classes
+    share the top score and one of them is the target, the target ranks 1,
+    not 2. An ``argsort``-based implementation would break ties by the
+    platform's sort stability, which is an implementation detail the caller
+    shouldn't depend on.
+
+    Returns an int64 tensor of shape ``(N,)``.
     """
-    order = logits.argsort(dim=-1, descending=True)         # (N, C)
-    matches = (order == targets.unsqueeze(-1)).int()         # (N, C)
-    rank_zero_indexed = matches.argmax(dim=-1)               # (N,)
-    return rank_zero_indexed + 1                              # 1-indexed
+    # (N, 1) gather — score of the true class per row
+    target_scores = logits.gather(dim=-1, index=targets.unsqueeze(-1))
+    # Count strictly higher-scoring classes; add 1 for the target itself.
+    higher = (logits > target_scores).sum(dim=-1)
+    return higher + 1
 
 
 def _mean_reciprocal_rank(logits: torch.Tensor, targets: torch.Tensor) -> float:
@@ -101,10 +107,9 @@ def compute_classification_metrics(
         ``dict[str, float]``: every value is a plain Python float, safe to
         pass straight into ``MetricStore.log(**kwargs)``.
 
-    Edge cases:
-        * Empty batch (``N == 0``): returns all zeros. Callers should guard
-          against this upstream, but we handle it defensively so tests with
-          degenerate loaders don't crash.
+    Empty batch (``N == 0``) is tolerated and returns zeros for every key
+    the non-empty path would have produced — this keeps test harnesses with
+    degenerate loaders happy without forcing a guard at every call site.
     """
     if logits.ndim != 2:
         raise ValueError(f"logits must be 2-D (N, C); got shape {tuple(logits.shape)}")

--- a/src/tracking/records.py
+++ b/src/tracking/records.py
@@ -11,7 +11,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +36,35 @@ class RecordComparison:
     @property
     def any_new_record(self) -> bool:
         return any(t.is_new_record for t in self.tasks)
+
+
+def _build_task_entry(
+    f1_mean: float,
+    task_summary: Dict,
+    run_folder: str,
+    now: str,
+) -> Dict:
+    """Build a single task entry for ``best_record.json``."""
+    return {
+        "f1_mean": f1_mean,
+        "f1_std": task_summary.get("f1", {}).get("std", 0.0),
+        "accuracy_mean": task_summary.get("accuracy", {}).get("mean", 0.0),
+        "run_folder": run_folder,
+        "updated_at": now,
+    }
+
+
+def _write_record(record_path: Path, tasks_record: Dict, now: str) -> Path:
+    """Write the ``best_record.json`` file."""
+    record = {
+        "last_updated": now,
+        "tasks": tasks_record,
+    }
+    record_path.write_text(
+        json.dumps(record, indent=4, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return record_path
 
 
 def scan_previous_bests(
@@ -76,6 +105,18 @@ def scan_previous_bests(
     return bests
 
 
+def _load_task_summary(results_dir: Path, run_folder: str, task: str) -> Dict:
+    """Read the task's block from a run's ``full_summary.json``."""
+    summary_path = results_dir / run_folder / "summary" / "full_summary.json"
+    if not summary_path.exists():
+        return {}
+    try:
+        data = json.loads(summary_path.read_text(encoding="utf-8"))
+        return data.get(task, {})
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
 def compare_records(
     results_dir: Path,
     current_summary: Dict,
@@ -99,7 +140,9 @@ def compare_records(
             continue
 
         prev_f1, prev_run = previous.get(task, (0.0, ""))
-        is_new = current_f1 > prev_f1 or prev_run == ""
+        # A degenerate run (F1=0.0) is never a meaningful record.
+        # For a genuine first run (no previous), only mark as record if F1 > 0.
+        is_new = current_f1 > prev_f1 if prev_run != "" else current_f1 > 0.0
 
         comparison.tasks.append(TaskRecord(
             task=task,
@@ -117,8 +160,14 @@ def save_best_record(
     comparison: RecordComparison,
     current_summary: Dict,
     current_folder: str,
-) -> Path:
-    """Write/update ``results_dir/best_record.json`` with per-task bests."""
+) -> Optional[Path]:
+    """Write/update ``results_dir/best_record.json`` with per-task bests.
+
+    Returns the path if written, ``None`` if nothing changed.
+    """
+    if not comparison.any_new_record:
+        return None
+
     record_path = results_dir / "best_record.json"
     now = datetime.now().isoformat(timespec="seconds")
 
@@ -135,24 +184,11 @@ def save_best_record(
     for tr in comparison.tasks:
         if tr.is_new_record:
             task_summary = current_summary.get(tr.task, {})
-            tasks_record[tr.task] = {
-                "f1_mean": tr.current_f1,
-                "f1_std": task_summary.get("f1", {}).get("std", 0.0),
-                "accuracy_mean": task_summary.get("accuracy", {}).get("mean", 0.0),
-                "run_folder": current_folder,
-                "updated_at": now,
-            }
+            tasks_record[tr.task] = _build_task_entry(
+                tr.current_f1, task_summary, current_folder, now,
+            )
 
-    record = {
-        "last_updated": now,
-        "tasks": tasks_record,
-    }
-
-    record_path.write_text(
-        json.dumps(record, indent=4, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
-    return record_path
+    return _write_record(record_path, tasks_record, now)
 
 
 def compute_best_record(results_dir: Path) -> Path:
@@ -166,31 +202,7 @@ def compute_best_record(results_dir: Path) -> Path:
 
     tasks_record = {}
     for task, (f1_mean, run_folder) in bests.items():
-        # Read the full summary to get companion metrics.
-        summary_path = results_dir / run_folder / "summary" / "full_summary.json"
-        task_summary: Dict = {}
-        if summary_path.exists():
-            try:
-                data = json.loads(summary_path.read_text(encoding="utf-8"))
-                task_summary = data.get(task, {})
-            except (json.JSONDecodeError, OSError):
-                pass
+        task_summary = _load_task_summary(results_dir, run_folder, task)
+        tasks_record[task] = _build_task_entry(f1_mean, task_summary, run_folder, now)
 
-        tasks_record[task] = {
-            "f1_mean": f1_mean,
-            "f1_std": task_summary.get("f1", {}).get("std", 0.0),
-            "accuracy_mean": task_summary.get("accuracy", {}).get("mean", 0.0),
-            "run_folder": run_folder,
-            "updated_at": now,
-        }
-
-    record_path = results_dir / "best_record.json"
-    record = {
-        "last_updated": now,
-        "tasks": tasks_record,
-    }
-    record_path.write_text(
-        json.dumps(record, indent=4, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
-    return record_path
+    return _write_record(results_dir / "best_record.json", tasks_record, now)

--- a/src/tracking/records.py
+++ b/src/tracking/records.py
@@ -1,0 +1,196 @@
+"""Best-run record tracking for engine+state result directories.
+
+Scans ``full_summary.json`` files across training runs to identify per-task
+F1 records, compares the current run against historical bests, and persists
+the record state to ``best_record.json`` at the engine+state root.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TaskRecord:
+    """Comparison result for a single task."""
+
+    task: str
+    current_f1: float
+    previous_best_f1: float  # 0.0 if no prior runs
+    previous_best_run: str  # folder name of prior best, "" if none
+    is_new_record: bool
+
+
+@dataclass
+class RecordComparison:
+    """Aggregated comparison across all tasks in a run."""
+
+    tasks: List[TaskRecord] = field(default_factory=list)
+
+    @property
+    def any_new_record(self) -> bool:
+        return any(t.is_new_record for t in self.tasks)
+
+
+def scan_previous_bests(
+    results_dir: Path,
+    exclude_folder: str = "",
+) -> Dict[str, Tuple[float, str]]:
+    """Scan all ``full_summary.json`` in *results_dir*, return per-task best.
+
+    Returns ``{task: (best_mean_f1, run_folder_name)}``.
+    *exclude_folder* is the current run's folder name — skipped to avoid
+    self-comparison.
+    """
+    bests: Dict[str, Tuple[float, str]] = {}
+
+    for summary_path in sorted(results_dir.glob("*/summary/full_summary.json")):
+        run_folder = summary_path.parent.parent.name
+        if run_folder == exclude_folder:
+            continue
+        try:
+            data = json.loads(summary_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Skipping unreadable summary %s: %s", summary_path, exc)
+            continue
+
+        for task, metrics in data.items():
+            if not isinstance(metrics, dict):
+                continue
+            f1_block = metrics.get("f1")
+            if not isinstance(f1_block, dict):
+                continue
+            f1_mean = f1_block.get("mean")
+            if not isinstance(f1_mean, (int, float)):
+                continue
+            prev_best, _ = bests.get(task, (0.0, ""))
+            if f1_mean > prev_best:
+                bests[task] = (f1_mean, run_folder)
+
+    return bests
+
+
+def compare_records(
+    results_dir: Path,
+    current_summary: Dict,
+    current_folder: str,
+) -> RecordComparison:
+    """Compare the current run's metrics against historical bests.
+
+    *current_summary* is the parsed ``full_summary.json`` of the current run.
+    """
+    previous = scan_previous_bests(results_dir, exclude_folder=current_folder)
+    comparison = RecordComparison()
+
+    for task, metrics in current_summary.items():
+        if not isinstance(metrics, dict):
+            continue
+        f1_block = metrics.get("f1")
+        if not isinstance(f1_block, dict):
+            continue
+        current_f1 = f1_block.get("mean", 0.0)
+        if not isinstance(current_f1, (int, float)):
+            continue
+
+        prev_f1, prev_run = previous.get(task, (0.0, ""))
+        is_new = current_f1 > prev_f1 or prev_run == ""
+
+        comparison.tasks.append(TaskRecord(
+            task=task,
+            current_f1=current_f1,
+            previous_best_f1=prev_f1,
+            previous_best_run=prev_run,
+            is_new_record=is_new,
+        ))
+
+    return comparison
+
+
+def save_best_record(
+    results_dir: Path,
+    comparison: RecordComparison,
+    current_summary: Dict,
+    current_folder: str,
+) -> Path:
+    """Write/update ``results_dir/best_record.json`` with per-task bests."""
+    record_path = results_dir / "best_record.json"
+    now = datetime.now().isoformat(timespec="seconds")
+
+    # Load existing record if present.
+    existing: Dict = {}
+    if record_path.exists():
+        try:
+            existing = json.loads(record_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    tasks_record = existing.get("tasks", {})
+
+    for tr in comparison.tasks:
+        if tr.is_new_record:
+            task_summary = current_summary.get(tr.task, {})
+            tasks_record[tr.task] = {
+                "f1_mean": tr.current_f1,
+                "f1_std": task_summary.get("f1", {}).get("std", 0.0),
+                "accuracy_mean": task_summary.get("accuracy", {}).get("mean", 0.0),
+                "run_folder": current_folder,
+                "updated_at": now,
+            }
+
+    record = {
+        "last_updated": now,
+        "tasks": tasks_record,
+    }
+
+    record_path.write_text(
+        json.dumps(record, indent=4, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return record_path
+
+
+def compute_best_record(results_dir: Path) -> Path:
+    """Standalone: scan all runs in *results_dir*, write ``best_record.json``.
+
+    Useful for the pipeline script to compute records outside of a training run.
+    Returns the path to the written ``best_record.json``.
+    """
+    bests = scan_previous_bests(results_dir, exclude_folder="")
+    now = datetime.now().isoformat(timespec="seconds")
+
+    tasks_record = {}
+    for task, (f1_mean, run_folder) in bests.items():
+        # Read the full summary to get companion metrics.
+        summary_path = results_dir / run_folder / "summary" / "full_summary.json"
+        task_summary: Dict = {}
+        if summary_path.exists():
+            try:
+                data = json.loads(summary_path.read_text(encoding="utf-8"))
+                task_summary = data.get(task, {})
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        tasks_record[task] = {
+            "f1_mean": f1_mean,
+            "f1_std": task_summary.get("f1", {}).get("std", 0.0),
+            "accuracy_mean": task_summary.get("accuracy", {}).get("mean", 0.0),
+            "run_folder": run_folder,
+            "updated_at": now,
+        }
+
+    record_path = results_dir / "best_record.json"
+    record = {
+        "last_updated": now,
+        "tasks": tasks_record,
+    }
+    record_path.write_text(
+        json.dumps(record, indent=4, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return record_path

--- a/src/tracking/storage.py
+++ b/src/tracking/storage.py
@@ -263,12 +263,24 @@ class HistoryStorage:
                 df = pd.DataFrame([{'Category': k, **v} for k, v in report.items()])
 
                 be = th.best.best_epoch
-                acc_vals = th.val.get('accuracy')
-                f1_vals = th.val.get('f1')
-                acc = acc_vals[be] if acc_vals and be < len(acc_vals) else None
-                f1 = f1_vals[be] if f1_vals and be < len(f1_vals) else None
+                # Export every metric present in the val MetricStore at the
+                # best epoch — no hardcoded (f1, accuracy) list, so new
+                # metrics (f1_weighted, top3_acc, mrr, ndcg_*) flow into
+                # fold_info.json automatically.
+                metrics_at_best: Dict[str, Any] = {}
+                if be >= 0:
+                    for metric_name, values in th.val.items():
+                        if be < len(values):
+                            metrics_at_best[metric_name] = values[be]
                 fold_info['best_epochs'][task] = {
-                    'epoch': be, 'accuracy': acc, 'f1': f1, 'time': th.best.best_time
+                    'epoch': be,
+                    'time': th.best.best_time,
+                    'metrics': metrics_at_best,
+                    # Legacy top-level keys kept so downstream consumers that
+                    # read fold_info['best_epochs'][task]['accuracy'] keep
+                    # working without a shim.
+                    'accuracy': metrics_at_best.get('accuracy'),
+                    'f1': metrics_at_best.get('f1'),
                 }
 
                 save_csv(df, path / f'fold{i}_{task}_report.csv', float_format='%.4f')

--- a/src/training/evaluate.py
+++ b/src/training/evaluate.py
@@ -19,22 +19,32 @@ def collect_predictions(
     loader: DataLoader,
     device: torch.device,
     forward_fn: Optional[Callable] = None,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Run model over loader, return (predictions, targets) as numpy.
+) -> tuple[np.ndarray, np.ndarray, torch.Tensor]:
+    """Run model over loader, return ``(predictions, targets, logits)``.
+
+    Logits are preserved (on-device, detached) so downstream code can compute
+    ranking metrics (Top-K, MRR, NDCG@K) without a second pass. ``predictions``
+    and ``targets`` are still returned as numpy for the sklearn
+    classification_report path.
 
     Args:
-        model: The model to evaluate (must be in eval mode or will be set).
-        loader: DataLoader yielding (X_batch, y_batch) tuples.
+        model: The model to evaluate (will be set to ``.eval()``).
+        loader: DataLoader yielding ``(X_batch, y_batch)`` tuples.
         device: Device to run on.
-        forward_fn: Optional callable(model, X_batch) -> logits.
-            If None, uses model(X_batch). Useful for MTL where the
+        forward_fn: Optional ``callable(model, X_batch) -> logits``.
+            If ``None``, uses ``model(X_batch)``. Useful for MTL where the
             model returns a tuple and only one head is needed.
 
     Returns:
-        Tuple of (predictions, targets) as numpy int arrays.
+        Tuple ``(preds, targets, logits)``:
+            * ``preds`` — ``np.ndarray[int]`` of argmax predictions.
+            * ``targets`` — ``np.ndarray[int]`` of true labels.
+            * ``logits`` — ``torch.Tensor`` of shape ``(N, C)`` (detached),
+              kept on ``device`` to avoid unnecessary transfers when the
+              caller wants to run ``compute_classification_metrics``.
     """
     model.eval()
-    preds_list, targets_list = [], []
+    logits_list, targets_list = [], []
 
     for X_batch, y_batch in loader:
         X_batch = X_batch.to(device, non_blocking=True)
@@ -44,12 +54,13 @@ def collect_predictions(
         else:
             logits = model(X_batch)
 
-        preds_list.append(logits.argmax(dim=1))
+        logits_list.append(logits.detach())
         targets_list.append(y_batch)
 
-    preds = torch.cat(preds_list).cpu().numpy()
+    all_logits = torch.cat(logits_list)
+    preds = all_logits.argmax(dim=1).cpu().numpy()
     targets = torch.cat(targets_list).cpu().numpy()
-    return preds, targets
+    return preds, targets, all_logits
 
 
 def build_report(

--- a/src/training/runners/_single_task_train.py
+++ b/src/training/runners/_single_task_train.py
@@ -13,6 +13,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from tracking.fold import FoldHistory
+from tracking.metrics import compute_classification_metrics
 from training.callbacks import CallbackContext, CallbackList
 
 logger = logging.getLogger(__name__)
@@ -68,7 +69,7 @@ def train_single_task(
         running_loss = torch.tensor(0.0, device=device)
         running_correct = torch.tensor(0, device=device, dtype=torch.long)
         total = 0
-        train_preds_list, train_targets_list = [], []
+        train_logits_list, train_targets_list = [], []
         epoch_grad_norms = []
 
         for X_batch, y_batch in train_loader:
@@ -84,13 +85,17 @@ def train_single_task(
             if scheduler is not None:
                 scheduler.step()
 
+            # Cheap top-1 accuracy accumulation (no logit retention).
             preds = logits.argmax(dim=1)
             running_loss += loss.detach() * y_batch.size(0)
             running_correct += (preds == y_batch).sum()
             total += y_batch.size(0)
 
+            # Only keep logits when the caller opted into full train metrics.
+            # Retaining all train logits would balloon memory for large
+            # datasets, so the legacy ``compute_train_f1`` flag still gates it.
             if compute_train_f1:
-                train_preds_list.append(preds.detach())
+                train_logits_list.append(logits.detach())
                 train_targets_list.append(y_batch)
 
         if total == 0:
@@ -98,52 +103,57 @@ def train_single_task(
         train_loss = running_loss.item() / total
         train_acc = running_correct.item() / total
 
-        if compute_train_f1 and train_preds_list:
-            train_preds = torch.cat(train_preds_list)
+        if compute_train_f1 and train_logits_list:
+            train_logits = torch.cat(train_logits_list)
             train_targets = torch.cat(train_targets_list)
-            train_f1 = multiclass_f1_score(
-                train_preds, train_targets,
-                num_classes=num_classes, average='macro', zero_division=0,
-            ).item()
+            train_metrics = compute_classification_metrics(
+                train_logits, train_targets, num_classes=num_classes,
+            )
+            train_f1 = train_metrics['f1']
+            # Prefer the torchmetrics-derived accuracy — identical value,
+            # avoids drift if the running_correct path is ever removed.
+            train_acc = train_metrics['accuracy']
             avg_grad_norm = float(torch.stack(epoch_grad_norms).mean().item()) if epoch_grad_norms else 0.0
         else:
+            # Fallback: only loss + cheap top-1 accuracy are logged.
+            train_metrics = {'accuracy': train_acc}
             train_f1 = 0.0
             avg_grad_norm = 0.0
 
         # Validation
         model.eval()
         val_running_loss = torch.tensor(0.0, device=device)
-        val_running_correct = torch.tensor(0, device=device, dtype=torch.long)
         val_total = 0
-        val_preds_list, val_targets_list = [], []
+        val_logits_list, val_targets_list = [], []
 
         with torch.no_grad():
             for X_batch, y_batch in val_loader:
                 X_batch, y_batch = X_batch.to(device, non_blocking=True), y_batch.to(device, non_blocking=True)
                 logits = model(X_batch)
                 loss = criterion(logits, y_batch)
-                preds = logits.argmax(dim=1)
 
                 val_running_loss += loss.detach() * y_batch.size(0)
-                val_running_correct += (preds == y_batch).sum()
                 val_total += y_batch.size(0)
 
-                val_preds_list.append(preds)
+                val_logits_list.append(logits)
                 val_targets_list.append(y_batch)
 
         if val_total == 0:
             continue
         val_loss = val_running_loss.item() / val_total
-        val_acc = val_running_correct.item() / val_total
-        val_preds = torch.cat(val_preds_list)
+        val_logits = torch.cat(val_logits_list)
         val_targets = torch.cat(val_targets_list)
-        val_f1 = multiclass_f1_score(
-            val_preds, val_targets,
-            num_classes=num_classes, average='macro', zero_division=0,
-        ).item()
+        val_metrics = compute_classification_metrics(
+            val_logits, val_targets, num_classes=num_classes,
+        )
+        val_f1 = val_metrics['f1']
+        val_acc = val_metrics['accuracy']
 
-        # Per-class F1 diagnostics
+        # Per-class F1 diagnostics (kept separate: goes to fold.diagnostics,
+        # not to the task MetricStore — the docs call out per-class as a
+        # detailed breakdown, not a headline metric).
         if diagnostic_class_names:
+            val_preds = val_logits.argmax(dim=1)
             per_class = multiclass_f1_score(
                 val_preds, val_targets,
                 num_classes=num_classes, average=None, zero_division=0,
@@ -154,14 +164,13 @@ def train_single_task(
                 **{f'per_class_f1_{name}': float(f1) for name, f1 in zip(diagnostic_class_names, per_class)},
             )
 
-        history.log_train(task_name, loss=train_loss, accuracy=train_acc, f1=train_f1)
+        history.log_train(task_name, loss=train_loss, **train_metrics)
         current_best = history.task(task_name).best.best_value
         is_improvement = val_f1 > current_best
         history.log_val(
             task_name,
             loss=val_loss,
-            accuracy=val_acc,
-            f1=val_f1,
+            **val_metrics,
             model_state=model.state_dict() if is_improvement else None,
             elapsed_time=history.timer.timer(),
         )

--- a/src/training/runners/_single_task_train.py
+++ b/src/training/runners/_single_task_train.py
@@ -115,8 +115,12 @@ def train_single_task(
             train_acc = train_metrics['accuracy']
             avg_grad_norm = float(torch.stack(epoch_grad_norms).mean().item()) if epoch_grad_norms else 0.0
         else:
-            # Fallback: only loss + cheap top-1 accuracy are logged.
-            train_metrics = {'accuracy': train_acc}
+            # Fallback: only loss + cheap top-1 accuracy are computed. We
+            # still emit an ``f1`` key (=0.0) so ``fold{i}_{task}_train.csv``
+            # columns stay stable across runs with/without
+            # ``compute_train_f1``; anything analysing CSV schemas would
+            # otherwise see a column disappear from old-style runs.
+            train_metrics = {'accuracy': train_acc, 'f1': 0.0}
             train_f1 = 0.0
             avg_grad_norm = 0.0
 

--- a/src/training/runners/mtl_cv.py
+++ b/src/training/runners/mtl_cv.py
@@ -206,17 +206,19 @@ def train_model(model: torch.nn.Module,
             cat_improved = f1_val_category > fold_history.task('category').best.best_value
             state = model.state_dict() if (next_improved or cat_improved) else None
 
+            # Per-task val losses now come from evaluate_model() inside the
+            # metric dicts, so log_val no longer needs a hand-wired scalar.
+            # model_task keeps the combined MTL loss; the f1=0/accuracy=0
+            # placeholders stay as stable schema on the MTL summary store.
             fold_history.model_task.log_val(loss=loss_val, f1=0, accuracy=0)
             fold_history.log_val(
                 'next',
-                loss=0,
                 **val_metrics_next,
                 model_state=state if next_improved else None,
                 elapsed_time=fold_history.timer.timer(),
             )
             fold_history.log_val(
                 'category',
-                loss=0,
                 **val_metrics_cat,
                 model_state=state if cat_improved else None,
                 elapsed_time=fold_history.timer.timer(),

--- a/src/training/runners/mtl_cv.py
+++ b/src/training/runners/mtl_cv.py
@@ -8,8 +8,8 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 from torch.nn import CrossEntropyLoss
-from torchmetrics.functional.classification import multiclass_f1_score, multiclass_accuracy
 
+from tracking.metrics import compute_classification_metrics
 from utils.flops import calculate_model_flops
 from utils.mps import clear_mps_cache
 from utils.progress import TrainingProgressBar
@@ -94,9 +94,11 @@ def train_model(model: torch.nn.Module,
         category_running_loss = torch.tensor(0.0, device=DEVICE)
         steps = 0
 
-        # Collect predictions on-device, compute metrics once per epoch
-        all_next_preds, all_next_targets = [], []
-        all_cat_preds, all_cat_targets = [], []
+        # Collect logits on-device so compute_classification_metrics() can
+        # produce the full metric dict (Macro/Weighted F1, Top-K, MRR, NDCG)
+        # in a single per-epoch call.
+        all_next_logits, all_next_targets = [], []
+        all_cat_logits, all_cat_targets = [], []
 
         # Iterate over batches with automatic progress tracking
         # (zero_grad is called inside the loop on every batch — no need to
@@ -138,40 +140,31 @@ def train_model(model: torch.nn.Module,
             next_running_loss += next_loss.detach()
             category_running_loss += category_loss.detach()
 
-            # Collect predictions on-device for epoch-level metrics
+            # Collect logits on-device for epoch-level metrics. We keep the
+            # full logit tensor (not argmax) so ranking metrics are free.
             with torch.no_grad():
-                all_next_preds.append(torch.argmax(pred_next, dim=1))
+                all_next_logits.append(pred_next.detach())
                 all_next_targets.append(truth_next)
-                all_cat_preds.append(torch.argmax(pred_category, dim=1))
+                all_cat_logits.append(pred_category.detach())
                 all_cat_targets.append(truth_category)
 
             steps += 1
 
-        # Stay on device — torchmetrics functional API computes metrics
-        # without bulk-transferring per-epoch predictions to CPU.
-        epoch_next_preds = torch.cat(all_next_preds)
+        epoch_next_logits = torch.cat(all_next_logits)
         epoch_next_targets = torch.cat(all_next_targets)
-        epoch_cat_preds = torch.cat(all_cat_preds)
+        epoch_cat_logits = torch.cat(all_cat_logits)
         epoch_cat_targets = torch.cat(all_cat_targets)
 
-        # Compute metrics once per epoch (matches the previous sklearn
-        # call site, but on-device with a single .item() sync per metric).
-        f1_next = multiclass_f1_score(
-            epoch_next_preds, epoch_next_targets,
-            num_classes=num_classes, average='macro', zero_division=0,
-        ).item()
-        next_acc = multiclass_accuracy(
-            epoch_next_preds, epoch_next_targets,
-            num_classes=num_classes, average='micro',
-        ).item()
-        f1_category = multiclass_f1_score(
-            epoch_cat_preds, epoch_cat_targets,
-            num_classes=num_classes, average='macro', zero_division=0,
-        ).item()
-        category_acc = multiclass_accuracy(
-            epoch_cat_preds, epoch_cat_targets,
-            num_classes=num_classes, average='micro',
-        ).item()
+        train_metrics_next = compute_classification_metrics(
+            epoch_next_logits, epoch_next_targets, num_classes=num_classes,
+        )
+        train_metrics_cat = compute_classification_metrics(
+            epoch_cat_logits, epoch_cat_targets, num_classes=num_classes,
+        )
+        f1_next = train_metrics_next['f1']
+        next_acc = train_metrics_next['accuracy']
+        f1_category = train_metrics_cat['f1']
+        category_acc = train_metrics_cat['accuracy']
 
         # Calculate epoch metrics (single sync for losses)
         epoch_loss = running_loss.item() / steps
@@ -185,18 +178,16 @@ def train_model(model: torch.nn.Module,
         })
 
         fold_history.model_task.log_train(loss=epoch_loss, accuracy=0)
-        fold_history.log_train('next',
-                               loss=epoch_loss_next,
-                               f1=f1_next,
-                               accuracy=next_acc)
-        fold_history.log_train('category',
-                               loss=epoch_loss_category,
-                               f1=f1_category,
-                               accuracy=category_acc)
+        fold_history.log_train(
+            'next', loss=epoch_loss_next, **train_metrics_next,
+        )
+        fold_history.log_train(
+            'category', loss=epoch_loss_category, **train_metrics_cat,
+        )
 
         # Validation phase with progress tracking
         with progress.validation():
-            acc_val_next, f1_val_next, acc_val_category, f1_val_category, loss_val = evaluate_model(
+            val_metrics_next, val_metrics_cat, loss_val = evaluate_model(
                 model,
                 [dataloader_next.val.dataloader, dataloader_category.val.dataloader],
                 next_criterion,
@@ -205,7 +196,12 @@ def train_model(model: torch.nn.Module,
                 DEVICE,
             )
 
-            # Only create state_dict when at least one task improves
+            f1_val_next = val_metrics_next['f1']
+            f1_val_category = val_metrics_cat['f1']
+            acc_val_next = val_metrics_next['accuracy']
+            acc_val_category = val_metrics_cat['accuracy']
+
+            # Only create state_dict when at least one task improves.
             next_improved = f1_val_next > fold_history.task('next').best.best_value
             cat_improved = f1_val_category > fold_history.task('category').best.best_value
             state = model.state_dict() if (next_improved or cat_improved) else None
@@ -214,16 +210,14 @@ def train_model(model: torch.nn.Module,
             fold_history.log_val(
                 'next',
                 loss=0,
-                accuracy=acc_val_next,
-                f1=f1_val_next,
+                **val_metrics_next,
                 model_state=state if next_improved else None,
                 elapsed_time=fold_history.timer.timer(),
             )
             fold_history.log_val(
                 'category',
                 loss=0,
-                accuracy=acc_val_category,
-                f1=f1_val_category,
+                **val_metrics_cat,
                 model_state=state if cat_improved else None,
                 elapsed_time=fold_history.timer.timer(),
             )

--- a/src/training/runners/mtl_eval.py
+++ b/src/training/runners/mtl_eval.py
@@ -66,6 +66,15 @@ def evaluate_model(model, dataloaders, next_criterion, category_criterion, mtl_c
         truths_cat_list.append(y_category)
         batches += 1
 
+    if batches == 0:
+        empty = compute_classification_metrics(
+            torch.zeros(0, model.num_classes, device=device),
+            torch.zeros(0, dtype=torch.long, device=device),
+            num_classes=model.num_classes,
+        )
+        empty['loss'] = 0.0
+        return empty, dict(empty), 0.0
+
     loss_combined = combined_running_loss.item() / batches
     loss_next = next_running_loss.item() / batches
     loss_category = category_running_loss.item() / batches

--- a/src/training/runners/mtl_eval.py
+++ b/src/training/runners/mtl_eval.py
@@ -1,32 +1,36 @@
 import torch
-from torchmetrics.functional.classification import multiclass_f1_score, multiclass_accuracy
 
+from tracking.metrics import compute_classification_metrics
 from utils.progress import zip_longest_cycle
 
 
 @torch.no_grad()
 def evaluate_model(model, dataloaders, next_criterion, category_criterion, mtl_creterion, device):
-    """
-    Unified evaluation function for both validation and testing.
+    """Unified MTL validation pass — computes loss and the full metric dict per task.
 
-    Uses zip_longest_cycle() to match training coverage — the shorter loader
-    is cycled so all samples from both loaders are evaluated.
+    Uses ``zip_longest_cycle`` to match training coverage — the shorter loader
+    is cycled so all samples from both loaders are evaluated. Logits are kept
+    on-device through ``compute_classification_metrics``, which produces the
+    legacy ``f1``/``accuracy`` keys **plus** ``f1_weighted``, ``accuracy_macro``,
+    ``top{k}_acc``, ``mrr`` and ``ndcg_{k}``.
 
     Args:
-        model: The MTLPOI model
-        dataloaders: List of [next_dataloader, category_dataloader]
-        next_criterion: Loss function for next task
-        category_criterion: Loss function for category task
-        mtl_creterion: MTL loss (unused for validation loss, kept for API compat)
-        device: Device to run evaluation on
+        model: The MTLPOI model.
+        dataloaders: List of ``[next_dataloader, category_dataloader]``.
+        next_criterion: Loss function for the next task.
+        category_criterion: Loss function for the category task.
+        mtl_creterion: MTL loss (unused for validation loss — kept for API compat).
+        device: Device to run evaluation on.
 
     Returns:
-        Tuple of (acc_next, f1_next, acc_category, f1_category, loss)
+        Tuple ``(metrics_next, metrics_category, loss)`` where each
+        ``metrics_*`` is the unprefixed dict returned by
+        ``compute_classification_metrics``.
     """
     model.eval()
     running_loss = torch.tensor(0.0, device=device)
-    preds_next_list, truths_next_list = [], []
-    preds_cat_list, truths_cat_list = [], []
+    logits_next_list, truths_next_list = [], []
+    logits_cat_list, truths_cat_list = [], []
     batchs = 0
 
     for data_next, data_cat in zip_longest_cycle(*dataloaders):
@@ -39,48 +43,31 @@ def evaluate_model(model, dataloaders, next_criterion, category_criterion, mtl_c
             x_category = x_category.to(device, non_blocking=True)
             y_category = y_category.to(device, non_blocking=True)
 
-        # Forward pass
         cat_out, next_out = model((x_category, x_next))
-        pred_next, truth_next = next_out, y_next
-        pred_category, truth_category = cat_out, y_category
 
-        next_loss = next_criterion(pred_next, truth_next)
-        category_loss = category_criterion(pred_category, truth_category)
+        next_loss = next_criterion(next_out, y_next)
+        category_loss = category_criterion(cat_out, y_category)
         running_loss += (next_loss.detach() + category_loss.detach()) / 2
 
-        # Collect predictions on-device
-        preds_next_list.append(torch.argmax(pred_next, dim=1))
-        truths_next_list.append(truth_next)
-        preds_cat_list.append(torch.argmax(pred_category, dim=1))
-        truths_cat_list.append(truth_category)
+        logits_next_list.append(next_out.detach())
+        truths_next_list.append(y_next)
+        logits_cat_list.append(cat_out.detach())
+        truths_cat_list.append(y_category)
         batchs += 1
 
-    # Stay on device — torchmetrics functional API computes metrics
-    # without bulk-transferring all predictions to CPU.
     loss = running_loss.item() / batchs
-    all_predictions_next = torch.cat(preds_next_list)
+    all_logits_next = torch.cat(logits_next_list)
     all_truths_next = torch.cat(truths_next_list)
-    all_predictions_category = torch.cat(preds_cat_list)
+    all_logits_category = torch.cat(logits_cat_list)
     all_truths_category = torch.cat(truths_cat_list)
 
     num_classes = model.num_classes
 
-    f1_next = multiclass_f1_score(
-        all_predictions_next, all_truths_next,
-        num_classes=num_classes, average='macro', zero_division=0,
-    ).item()
-    acc_next = multiclass_accuracy(
-        all_predictions_next, all_truths_next,
-        num_classes=num_classes, average='micro',
-    ).item()
+    metrics_next = compute_classification_metrics(
+        all_logits_next, all_truths_next, num_classes=num_classes,
+    )
+    metrics_category = compute_classification_metrics(
+        all_logits_category, all_truths_category, num_classes=num_classes,
+    )
 
-    f1_category = multiclass_f1_score(
-        all_predictions_category, all_truths_category,
-        num_classes=num_classes, average='macro', zero_division=0,
-    ).item()
-    acc_category = multiclass_accuracy(
-        all_predictions_category, all_truths_category,
-        num_classes=num_classes, average='micro',
-    ).item()
-
-    return acc_next, f1_next, acc_category, f1_category, loss
+    return metrics_next, metrics_category, loss

--- a/src/training/runners/mtl_eval.py
+++ b/src/training/runners/mtl_eval.py
@@ -12,7 +12,9 @@ def evaluate_model(model, dataloaders, next_criterion, category_criterion, mtl_c
     is cycled so all samples from both loaders are evaluated. Logits are kept
     on-device through ``compute_classification_metrics``, which produces the
     legacy ``f1``/``accuracy`` keys **plus** ``f1_weighted``, ``accuracy_macro``,
-    ``top{k}_acc``, ``mrr`` and ``ndcg_{k}``.
+    ``top{k}_acc``, ``mrr`` and ``ndcg_{k}``. Each per-task metric dict also
+    carries its own ``'loss'`` key so the caller can forward the whole dict
+    via ``**`` straight into ``log_val`` without hand-wiring scalars.
 
     Args:
         model: The MTLPOI model.
@@ -23,15 +25,21 @@ def evaluate_model(model, dataloaders, next_criterion, category_criterion, mtl_c
         device: Device to run evaluation on.
 
     Returns:
-        Tuple ``(metrics_next, metrics_category, loss)`` where each
-        ``metrics_*`` is the unprefixed dict returned by
-        ``compute_classification_metrics``.
+        Tuple ``(metrics_next, metrics_category, loss_combined)``:
+            * ``metrics_next`` / ``metrics_category`` — dicts from
+              ``compute_classification_metrics`` with an added
+              per-task ``'loss'`` key.
+            * ``loss_combined`` — scalar average of
+              ``(next_loss + category_loss) / 2`` across batches, kept
+              for the MTL-level ``model_task`` tracking store.
     """
     model.eval()
-    running_loss = torch.tensor(0.0, device=device)
+    combined_running_loss = torch.tensor(0.0, device=device)
+    next_running_loss = torch.tensor(0.0, device=device)
+    category_running_loss = torch.tensor(0.0, device=device)
     logits_next_list, truths_next_list = [], []
     logits_cat_list, truths_cat_list = [], []
-    batchs = 0
+    batches = 0
 
     for data_next, data_cat in zip_longest_cycle(*dataloaders):
         x_next, y_next = data_next
@@ -47,15 +55,21 @@ def evaluate_model(model, dataloaders, next_criterion, category_criterion, mtl_c
 
         next_loss = next_criterion(next_out, y_next)
         category_loss = category_criterion(cat_out, y_category)
-        running_loss += (next_loss.detach() + category_loss.detach()) / 2
+        # Accumulate on-device; single .item() sync after the loop.
+        next_running_loss += next_loss.detach()
+        category_running_loss += category_loss.detach()
+        combined_running_loss += (next_loss.detach() + category_loss.detach()) / 2
 
         logits_next_list.append(next_out.detach())
         truths_next_list.append(y_next)
         logits_cat_list.append(cat_out.detach())
         truths_cat_list.append(y_category)
-        batchs += 1
+        batches += 1
 
-    loss = running_loss.item() / batchs
+    loss_combined = combined_running_loss.item() / batches
+    loss_next = next_running_loss.item() / batches
+    loss_category = category_running_loss.item() / batches
+
     all_logits_next = torch.cat(logits_next_list)
     all_truths_next = torch.cat(truths_next_list)
     all_logits_category = torch.cat(logits_cat_list)
@@ -69,5 +83,7 @@ def evaluate_model(model, dataloaders, next_criterion, category_criterion, mtl_c
     metrics_category = compute_classification_metrics(
         all_logits_category, all_truths_category, num_classes=num_classes,
     )
+    metrics_next['loss'] = loss_next
+    metrics_category['loss'] = loss_category
 
-    return metrics_next, metrics_category, loss
+    return metrics_next, metrics_category, loss_combined

--- a/tests/test_tracking/test_metrics.py
+++ b/tests/test_tracking/test_metrics.py
@@ -199,3 +199,43 @@ class TestEdgeCases:
         logits = torch.tensor([[5.0, 0.1], [0.1, 5.0]], device="cpu")
         m = compute_classification_metrics(logits, targets, num_classes=2)
         assert m["accuracy"] == pytest.approx(1.0)
+
+
+class TestTieBreaking:
+    """Explicitly document the tie-handling semantics of ``_rank_of_target``.
+
+    When multiple classes share the top logit and one of them is the target,
+    we count "how many classes strictly beat the target", so the target
+    gets the best-case rank. This is the canonical choice for ranking
+    metrics and avoids depending on ``argsort`` stability.
+    """
+
+    def test_all_tied_gives_rank_one(self):
+        # 3 classes, all with logit 0.5 — target should rank 1 (best case).
+        logits = torch.tensor([[0.5, 0.5, 0.5]])
+        targets = torch.tensor([1])
+        m = compute_classification_metrics(
+            logits, targets, num_classes=3, top_k=(3,)
+        )
+        assert m["mrr"] == pytest.approx(1.0)      # 1/rank = 1/1
+        assert m["top3_acc"] == pytest.approx(1.0)  # trivially in top-3
+
+    def test_target_tied_with_one_class_at_top(self):
+        # Classes 0 and 1 tied at the top; target = 0 → strictly-higher
+        # count is 0, so rank=1.
+        logits = torch.tensor([[5.0, 5.0, 1.0]])
+        targets = torch.tensor([0])
+        m = compute_classification_metrics(
+            logits, targets, num_classes=3, top_k=(3,)
+        )
+        assert m["mrr"] == pytest.approx(1.0)
+
+    def test_one_class_strictly_beats_target(self):
+        # Class 2 strictly wins; target=0 has the same score as class 1.
+        # strictly_higher = 1 (only class 2), so rank = 2.
+        logits = torch.tensor([[4.0, 4.0, 9.0]])
+        targets = torch.tensor([0])
+        m = compute_classification_metrics(
+            logits, targets, num_classes=3, top_k=(3,)
+        )
+        assert m["mrr"] == pytest.approx(0.5)  # 1/2

--- a/tests/test_tracking/test_metrics.py
+++ b/tests/test_tracking/test_metrics.py
@@ -1,0 +1,201 @@
+"""Unit tests for ``tracking.metrics.compute_classification_metrics``."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from tracking.metrics import compute_classification_metrics
+
+
+def _one_hot_logits(targets: torch.Tensor, num_classes: int, scale: float = 10.0) -> torch.Tensor:
+    """Build a perfect-logits tensor where the target class dominates."""
+    logits = torch.zeros(len(targets), num_classes)
+    logits[torch.arange(len(targets)), targets] = scale
+    return logits
+
+
+class TestPerfectPredictions:
+    def test_all_metrics_equal_one(self):
+        targets = torch.tensor([0, 1, 2, 3, 4, 5, 6])
+        logits = _one_hot_logits(targets, num_classes=7)
+
+        m = compute_classification_metrics(logits, targets, num_classes=7)
+
+        assert m["accuracy"] == pytest.approx(1.0)
+        assert m["accuracy_macro"] == pytest.approx(1.0)
+        assert m["f1"] == pytest.approx(1.0)
+        assert m["f1_weighted"] == pytest.approx(1.0)
+        assert m["mrr"] == pytest.approx(1.0)
+        assert m["top3_acc"] == pytest.approx(1.0)
+        assert m["top5_acc"] == pytest.approx(1.0)
+        # NDCG@K: target at rank 1 → DCG = 1/log2(2) = 1
+        assert m["ndcg_3"] == pytest.approx(1.0)
+        assert m["ndcg_5"] == pytest.approx(1.0)
+
+
+class TestWorstArgmaxButGoodTopK:
+    """Argmax always wrong, but the true class is still in the top-2."""
+
+    def test_top1_zero_top3_one(self):
+        # 3-class problem; target is always class 0, but logits put it at rank 2.
+        # order: class 1 (highest), class 0 (second), class 2 (lowest)
+        logits = torch.tensor([[0.5, 1.0, 0.1]] * 6)
+        targets = torch.tensor([0, 0, 0, 0, 0, 0])
+
+        m = compute_classification_metrics(logits, targets, num_classes=3, top_k=(3,))
+
+        assert m["accuracy"] == pytest.approx(0.0)
+        assert m["f1"] == pytest.approx(0.0)
+        # All samples hit within top-3 (k=3 covers all 3 classes).
+        assert m["top3_acc"] == pytest.approx(1.0)
+        # MRR: rank is 2 for every sample → 1/2
+        assert m["mrr"] == pytest.approx(0.5)
+        # NDCG@3: rank=2 → 1/log2(3)
+        assert m["ndcg_3"] == pytest.approx(1.0 / math.log2(3.0))
+
+
+class TestMRRAndNDCGAtRank2:
+    def test_known_rank(self):
+        # 4-class problem; true target (class 0) placed at rank 3.
+        # Descending order of classes in logits: 2 (3.0), 1 (2.0), 0 (1.0), 3 (0.5)
+        logits = torch.tensor([[1.0, 2.0, 3.0, 0.5]] * 4)
+        targets = torch.tensor([0, 0, 0, 0])
+
+        m = compute_classification_metrics(logits, targets, num_classes=4, top_k=(2, 3, 5))
+
+        assert m["mrr"] == pytest.approx(1.0 / 3.0)
+        assert m["top2_acc"] == pytest.approx(0.0)     # rank 3 not in top-2
+        assert m["top3_acc"] == pytest.approx(1.0)     # rank 3 is in top-3
+        assert m["top5_acc"] == pytest.approx(1.0)     # always in top-5
+        # NDCG@2: target not in top-2 → 0
+        assert m["ndcg_2"] == pytest.approx(0.0)
+        # NDCG@3: rank=3 → 1/log2(4) = 0.5
+        assert m["ndcg_3"] == pytest.approx(0.5)
+
+
+class TestImbalancedWeightedVsMacro:
+    def test_weighted_differs_from_macro_under_imbalance(self):
+        # Class 0 dominates and is perfectly classified.
+        # Class 1 appears twice, both misclassified as class 0.
+        # Macro F1 averages the two per-class F1s equally; weighted F1 gives
+        # much more weight to the majority class so it should be higher.
+        n_maj = 20
+        targets = torch.tensor([0] * n_maj + [1, 1])
+        logits = torch.zeros(n_maj + 2, 2)
+        logits[:, 0] = 5.0  # predict class 0 for every sample
+
+        m = compute_classification_metrics(logits, targets, num_classes=2, top_k=(3,))
+
+        assert m["f1_weighted"] > m["f1"], (
+            "weighted F1 should exceed macro F1 when the majority class is "
+            "perfectly classified and the minority class is ignored"
+        )
+        # Sanity: majority-class precision is < 1 (minority contaminates), but
+        # micro accuracy equals n_maj/(n_maj+2).
+        assert m["accuracy"] == pytest.approx(n_maj / (n_maj + 2))
+        # Balanced accuracy averages per-class recall: class 0 recall = 1,
+        # class 1 recall = 0 → 0.5.
+        assert m["accuracy_macro"] == pytest.approx(0.5)
+
+
+class TestPrefix:
+    def test_prefix_is_applied_to_every_key(self):
+        targets = torch.tensor([0, 1, 2])
+        logits = _one_hot_logits(targets, num_classes=3)
+
+        m = compute_classification_metrics(
+            logits, targets, num_classes=3, top_k=(3,), prefix="val_"
+        )
+
+        assert "val_accuracy" in m
+        assert "val_f1" in m
+        assert "val_f1_weighted" in m
+        assert "val_accuracy_macro" in m
+        assert "val_top3_acc" in m
+        assert "val_mrr" in m
+        assert "val_ndcg_3" in m
+        # No unprefixed leak.
+        assert "f1" not in m
+        assert "accuracy" not in m
+
+
+class TestEdgeCases:
+    def test_empty_batch_returns_zeros(self):
+        logits = torch.zeros(0, 7)
+        targets = torch.zeros(0, dtype=torch.long)
+
+        m = compute_classification_metrics(logits, targets, num_classes=7)
+
+        for key, value in m.items():
+            assert value == 0.0, f"{key} should be zero for empty batch, got {value}"
+
+    def test_single_sample(self):
+        logits = torch.tensor([[0.1, 5.0, 0.3]])
+        targets = torch.tensor([1])
+
+        m = compute_classification_metrics(logits, targets, num_classes=3, top_k=(3,))
+
+        assert m["accuracy"] == pytest.approx(1.0)
+        assert m["f1"] == pytest.approx(1.0)
+        assert m["mrr"] == pytest.approx(1.0)
+
+    def test_top_k_larger_than_num_classes_is_clamped(self):
+        targets = torch.tensor([0, 1])
+        logits = _one_hot_logits(targets, num_classes=3)
+
+        # k=10 > num_classes=3 — should not crash; equals top-3.
+        m = compute_classification_metrics(
+            logits, targets, num_classes=3, top_k=(10,)
+        )
+        assert m["top10_acc"] == pytest.approx(1.0)
+
+    def test_k_equal_one_is_skipped(self):
+        targets = torch.tensor([0, 1, 2])
+        logits = _one_hot_logits(targets, num_classes=3)
+
+        m = compute_classification_metrics(
+            logits, targets, num_classes=3, top_k=(1, 3)
+        )
+        # k=1 would just duplicate 'accuracy'; we explicitly skip it.
+        assert "top1_acc" not in m
+        assert "ndcg_1" not in m
+        assert "top3_acc" in m
+
+    def test_shape_validation(self):
+        # 1-D logits must raise
+        with pytest.raises(ValueError, match="logits must be 2-D"):
+            compute_classification_metrics(
+                torch.zeros(3), torch.zeros(3, dtype=torch.long), num_classes=3
+            )
+        # 2-D targets must raise
+        with pytest.raises(ValueError, match="targets must be 1-D"):
+            compute_classification_metrics(
+                torch.zeros(3, 3), torch.zeros(3, 1, dtype=torch.long), num_classes=3
+            )
+        # Mismatched N must raise
+        with pytest.raises(ValueError, match="logits N=.* != targets N=.*"):
+            compute_classification_metrics(
+                torch.zeros(4, 3), torch.zeros(3, dtype=torch.long), num_classes=3
+            )
+
+    def test_returns_python_floats(self):
+        """All values should be Python floats so MetricStore.log() works."""
+        targets = torch.tensor([0, 1, 2])
+        logits = _one_hot_logits(targets, num_classes=3)
+
+        m = compute_classification_metrics(logits, targets, num_classes=3)
+        for key, value in m.items():
+            assert isinstance(value, float), f"{key}={value!r} is {type(value).__name__}"
+
+    def test_cross_device_targets(self):
+        """If targets are on CPU and logits on a different device the fn must handle it."""
+        # We can't guarantee a second device in CI, so fake the check by
+        # confirming same-CPU inputs don't explode. The function contains a
+        # device-alignment branch that we exercise via this path.
+        targets = torch.tensor([0, 1], device="cpu")
+        logits = torch.tensor([[5.0, 0.1], [0.1, 5.0]], device="cpu")
+        m = compute_classification_metrics(logits, targets, num_classes=2)
+        assert m["accuracy"] == pytest.approx(1.0)

--- a/tests/test_tracking/test_ml_history.py
+++ b/tests/test_tracking/test_ml_history.py
@@ -684,6 +684,82 @@ class TestIntegrationStorage:
         assert len(df) == 3
 
 
+class TestIntegrationNewMetrics:
+    """End-to-end checks that the new metric keys (f1_weighted, top3_acc,
+    mrr, ndcg_{k}, accuracy_macro) flow through FoldHistory, storage, and
+    are reflected in fold_info.json and the auto-generated plots."""
+
+    def _make_history_with_new_metrics(self, tmp_path):
+        h = MLHistory('MetricTest', tasks='next', num_folds=1)
+        h.start()
+        h.set_model_parms(NeuralParams(batch_size=32, num_epochs=2, learning_rate=1e-3))
+
+        fold = h.get_curr_fold()
+        # Simulate compute_classification_metrics output across 3 epochs.
+        series = [
+            dict(loss=1.0, accuracy=0.50, accuracy_macro=0.48, f1=0.40,
+                 f1_weighted=0.55, top3_acc=0.80, top5_acc=0.90,
+                 mrr=0.60, ndcg_3=0.70, ndcg_5=0.75),
+            dict(loss=0.8, accuracy=0.60, accuracy_macro=0.58, f1=0.50,
+                 f1_weighted=0.65, top3_acc=0.85, top5_acc=0.92,
+                 mrr=0.70, ndcg_3=0.77, ndcg_5=0.80),
+            dict(loss=0.6, accuracy=0.70, accuracy_macro=0.68, f1=0.65,
+                 f1_weighted=0.75, top3_acc=0.90, top5_acc=0.95,
+                 mrr=0.80, ndcg_3=0.83, ndcg_5=0.86),
+        ]
+        for epoch_metrics in series:
+            fold.log_train('next', **epoch_metrics)
+            fold.log_val('next', model_state={'ok': True}, **epoch_metrics)
+
+        fold.task('next').report = {
+            'macro avg': {'precision': 0.7, 'recall': 0.65, 'f1-score': 0.65, 'support': 300}
+        }
+        h.step()
+        return h
+
+    def test_new_metric_keys_are_stored(self, tmp_path):
+        h = self._make_history_with_new_metrics(tmp_path)
+        val_keys = set(h.folds[0].task('next').val.keys())
+        expected = {
+            'loss', 'accuracy', 'accuracy_macro', 'f1', 'f1_weighted',
+            'top3_acc', 'top5_acc', 'mrr', 'ndcg_3', 'ndcg_5',
+        }
+        assert expected.issubset(val_keys), (
+            f"Missing new metric keys: {expected - val_keys}"
+        )
+
+    def test_fold_info_json_contains_all_metrics_at_best_epoch(self, tmp_path):
+        h = self._make_history_with_new_metrics(tmp_path)
+        base = h.storage.save(tmp_path)
+        fold_info = json.loads((base / 'folds' / 'fold1_info.json').read_text())
+        metrics_at_best = fold_info['best_epochs']['next']['metrics']
+        # Best epoch is epoch 2 (F1 = 0.65), so values should match the
+        # third row of the series above.
+        assert metrics_at_best['f1'] == pytest.approx(0.65)
+        assert metrics_at_best['f1_weighted'] == pytest.approx(0.75)
+        assert metrics_at_best['top3_acc'] == pytest.approx(0.90)
+        assert metrics_at_best['mrr'] == pytest.approx(0.80)
+        assert metrics_at_best['ndcg_3'] == pytest.approx(0.83)
+        # Legacy top-level keys still populated for backwards compatibility.
+        assert fold_info['best_epochs']['next']['f1'] == pytest.approx(0.65)
+        assert fold_info['best_epochs']['next']['accuracy'] == pytest.approx(0.70)
+
+    def test_plots_generated_for_all_metrics(self, tmp_path):
+        h = self._make_history_with_new_metrics(tmp_path)
+        base = h.storage.save(tmp_path)
+        plots_dir = base / 'plots' / 'next'
+        # Auto-discovery should produce one plot per tracked metric.
+        expected_plots = {
+            'loss.png', 'accuracy.png', 'accuracy_macro.png',
+            'f1.png', 'f1_weighted.png', 'top3_acc.png', 'top5_acc.png',
+            'mrr.png', 'ndcg_3.png', 'ndcg_5.png',
+        }
+        actual = {p.name for p in plots_dir.glob('*.png')}
+        assert expected_plots.issubset(actual), (
+            f"Missing plots: {expected_plots - actual}"
+        )
+
+
 # ── Group H: Auto-Lifecycle ──────────────────────────────────────────
 
 

--- a/tests/test_tracking/test_records.py
+++ b/tests/test_tracking/test_records.py
@@ -1,0 +1,225 @@
+"""Unit tests for ``tracking.records`` — best-run record tracking."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tracking.records import (
+    RecordComparison,
+    TaskRecord,
+    compare_records,
+    compute_best_record,
+    save_best_record,
+    scan_previous_bests,
+)
+
+
+def _write_summary(base: "Path", folder: str, summary: dict) -> None:
+    """Helper: write a fake full_summary.json under base/folder/summary/."""
+    summary_dir = base / folder / "summary"
+    summary_dir.mkdir(parents=True, exist_ok=True)
+    (summary_dir / "full_summary.json").write_text(
+        json.dumps(summary), encoding="utf-8"
+    )
+
+
+class TestScanPreviousBests:
+    def test_finds_max_f1_per_task(self, tmp_path):
+        _write_summary(tmp_path, "run_a", {
+            "category": {"f1": {"mean": 0.40, "std": 0.01}, "accuracy": {"mean": 0.50}},
+            "next": {"f1": {"mean": 0.30, "std": 0.02}, "accuracy": {"mean": 0.35}},
+        })
+        _write_summary(tmp_path, "run_b", {
+            "category": {"f1": {"mean": 0.50, "std": 0.01}, "accuracy": {"mean": 0.55}},
+            "next": {"f1": {"mean": 0.25, "std": 0.01}, "accuracy": {"mean": 0.30}},
+        })
+        _write_summary(tmp_path, "run_c", {
+            "category": {"f1": {"mean": 0.45, "std": 0.01}, "accuracy": {"mean": 0.52}},
+            "next": {"f1": {"mean": 0.35, "std": 0.03}, "accuracy": {"mean": 0.40}},
+        })
+
+        bests = scan_previous_bests(tmp_path)
+
+        assert bests["category"] == pytest.approx((0.50, "run_b"), abs=1e-9)
+        assert bests["next"] == pytest.approx((0.35, "run_c"), abs=1e-9)
+
+    def test_excludes_specified_folder(self, tmp_path):
+        _write_summary(tmp_path, "run_a", {
+            "category": {"f1": {"mean": 0.80, "std": 0.01}},
+        })
+        _write_summary(tmp_path, "run_b", {
+            "category": {"f1": {"mean": 0.40, "std": 0.01}},
+        })
+
+        bests = scan_previous_bests(tmp_path, exclude_folder="run_a")
+
+        assert bests["category"][0] == pytest.approx(0.40)
+        assert bests["category"][1] == "run_b"
+
+    def test_empty_dir_returns_empty(self, tmp_path):
+        assert scan_previous_bests(tmp_path) == {}
+
+    def test_corrupted_json_skipped(self, tmp_path):
+        summary_dir = tmp_path / "bad_run" / "summary"
+        summary_dir.mkdir(parents=True)
+        (summary_dir / "full_summary.json").write_text("not valid json")
+
+        _write_summary(tmp_path, "good_run", {
+            "next": {"f1": {"mean": 0.30, "std": 0.01}},
+        })
+
+        bests = scan_previous_bests(tmp_path)
+        assert "next" in bests
+        assert bests["next"][0] == pytest.approx(0.30)
+
+    def test_mixed_task_sets(self, tmp_path):
+        """MTL run has category+next, single-task run has only next."""
+        _write_summary(tmp_path, "mtl_run", {
+            "category": {"f1": {"mean": 0.45, "std": 0.01}},
+            "next": {"f1": {"mean": 0.30, "std": 0.01}},
+        })
+        _write_summary(tmp_path, "next_only_run", {
+            "next": {"f1": {"mean": 0.40, "std": 0.01}},
+        })
+
+        bests = scan_previous_bests(tmp_path)
+        assert bests["category"][0] == pytest.approx(0.45)
+        assert bests["next"][0] == pytest.approx(0.40)
+        assert bests["next"][1] == "next_only_run"
+
+
+class TestCompareRecords:
+    def test_new_record(self, tmp_path):
+        _write_summary(tmp_path, "old_run", {
+            "category": {"f1": {"mean": 0.40, "std": 0.01}},
+        })
+
+        current = {"category": {"f1": {"mean": 0.50, "std": 0.02}}}
+        comp = compare_records(tmp_path, current, "current_run")
+
+        assert len(comp.tasks) == 1
+        assert comp.tasks[0].is_new_record is True
+        assert comp.tasks[0].current_f1 == pytest.approx(0.50)
+        assert comp.tasks[0].previous_best_f1 == pytest.approx(0.40)
+        assert comp.any_new_record is True
+
+    def test_not_a_record(self, tmp_path):
+        _write_summary(tmp_path, "old_run", {
+            "next": {"f1": {"mean": 0.50, "std": 0.01}},
+        })
+
+        current = {"next": {"f1": {"mean": 0.40, "std": 0.02}}}
+        comp = compare_records(tmp_path, current, "current_run")
+
+        assert len(comp.tasks) == 1
+        assert comp.tasks[0].is_new_record is False
+        assert comp.tasks[0].previous_best_run == "old_run"
+        assert comp.any_new_record is False
+
+    def test_first_run_is_new_record(self, tmp_path):
+        current = {
+            "category": {"f1": {"mean": 0.40, "std": 0.01}},
+            "next": {"f1": {"mean": 0.30, "std": 0.01}},
+        }
+        comp = compare_records(tmp_path, current, "first_run")
+
+        assert len(comp.tasks) == 2
+        assert all(t.is_new_record for t in comp.tasks)
+
+    def test_mixed_tasks_some_record_some_not(self, tmp_path):
+        _write_summary(tmp_path, "old_run", {
+            "category": {"f1": {"mean": 0.50, "std": 0.01}},
+            "next": {"f1": {"mean": 0.20, "std": 0.01}},
+        })
+
+        current = {
+            "category": {"f1": {"mean": 0.45, "std": 0.01}},  # worse
+            "next": {"f1": {"mean": 0.30, "std": 0.01}},       # better
+        }
+        comp = compare_records(tmp_path, current, "new_run")
+
+        cat = next(t for t in comp.tasks if t.task == "category")
+        nxt = next(t for t in comp.tasks if t.task == "next")
+        assert cat.is_new_record is False
+        assert nxt.is_new_record is True
+        assert comp.any_new_record is True
+
+
+class TestSaveBestRecord:
+    def test_creates_best_record_json(self, tmp_path):
+        comparison = RecordComparison(tasks=[
+            TaskRecord("category", 0.50, 0.40, "old_run", True),
+            TaskRecord("next", 0.25, 0.30, "old_run", False),
+        ])
+        current_summary = {
+            "category": {"f1": {"mean": 0.50, "std": 0.02}, "accuracy": {"mean": 0.55}},
+            "next": {"f1": {"mean": 0.25, "std": 0.01}, "accuracy": {"mean": 0.30}},
+        }
+
+        path = save_best_record(tmp_path, comparison, current_summary, "new_run")
+
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert "category" in data["tasks"]
+        assert data["tasks"]["category"]["f1_mean"] == pytest.approx(0.50)
+        assert data["tasks"]["category"]["run_folder"] == "new_run"
+        # next was not a record — should not be in tasks (no prior entry either).
+        assert "next" not in data["tasks"]
+
+    def test_updates_existing_record(self, tmp_path):
+        # Pre-existing record.
+        existing = {
+            "last_updated": "2026-04-10T00:00:00",
+            "tasks": {
+                "next": {
+                    "f1_mean": 0.30,
+                    "f1_std": 0.01,
+                    "accuracy_mean": 0.35,
+                    "run_folder": "old_best",
+                    "updated_at": "2026-04-10T00:00:00",
+                }
+            },
+        }
+        (tmp_path / "best_record.json").write_text(json.dumps(existing))
+
+        comparison = RecordComparison(tasks=[
+            TaskRecord("category", 0.50, 0.0, "", True),
+        ])
+        current_summary = {
+            "category": {"f1": {"mean": 0.50, "std": 0.02}, "accuracy": {"mean": 0.55}},
+        }
+
+        save_best_record(tmp_path, comparison, current_summary, "new_run")
+
+        data = json.loads((tmp_path / "best_record.json").read_text())
+        # Both tasks should be present.
+        assert data["tasks"]["category"]["f1_mean"] == pytest.approx(0.50)
+        assert data["tasks"]["next"]["f1_mean"] == pytest.approx(0.30)
+
+
+class TestComputeBestRecord:
+    def test_standalone_computation(self, tmp_path):
+        _write_summary(tmp_path, "run_a", {
+            "category": {"f1": {"mean": 0.40, "std": 0.01}, "accuracy": {"mean": 0.50}},
+            "next": {"f1": {"mean": 0.35, "std": 0.02}, "accuracy": {"mean": 0.40}},
+        })
+        _write_summary(tmp_path, "run_b", {
+            "category": {"f1": {"mean": 0.50, "std": 0.02}, "accuracy": {"mean": 0.55}},
+            "next": {"f1": {"mean": 0.30, "std": 0.01}, "accuracy": {"mean": 0.35}},
+        })
+
+        path = compute_best_record(tmp_path)
+
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["tasks"]["category"]["f1_mean"] == pytest.approx(0.50)
+        assert data["tasks"]["category"]["run_folder"] == "run_b"
+        assert data["tasks"]["next"]["f1_mean"] == pytest.approx(0.35)
+        assert data["tasks"]["next"]["run_folder"] == "run_a"
+
+    def test_empty_dir_writes_empty_tasks(self, tmp_path):
+        path = compute_best_record(tmp_path)
+
+        data = json.loads(path.read_text())
+        assert data["tasks"] == {}

--- a/tests/test_tracking/test_records.py
+++ b/tests/test_tracking/test_records.py
@@ -127,6 +127,16 @@ class TestCompareRecords:
         assert len(comp.tasks) == 2
         assert all(t.is_new_record for t in comp.tasks)
 
+    def test_degenerate_first_run_not_a_record(self, tmp_path):
+        """A first run with F1=0.0 should not be marked as a record."""
+        current = {
+            "category": {"f1": {"mean": 0.0, "std": 0.0}},
+        }
+        comp = compare_records(tmp_path, current, "broken_run")
+
+        assert len(comp.tasks) == 1
+        assert comp.tasks[0].is_new_record is False
+
     def test_mixed_tasks_some_record_some_not(self, tmp_path):
         _write_summary(tmp_path, "old_run", {
             "category": {"f1": {"mean": 0.50, "std": 0.01}},
@@ -159,6 +169,7 @@ class TestSaveBestRecord:
 
         path = save_best_record(tmp_path, comparison, current_summary, "new_run")
 
+        assert path is not None
         assert path.exists()
         data = json.loads(path.read_text())
         assert "category" in data["tasks"]
@@ -166,6 +177,19 @@ class TestSaveBestRecord:
         assert data["tasks"]["category"]["run_folder"] == "new_run"
         # next was not a record — should not be in tasks (no prior entry either).
         assert "next" not in data["tasks"]
+
+    def test_returns_none_when_no_new_records(self, tmp_path):
+        comparison = RecordComparison(tasks=[
+            TaskRecord("next", 0.25, 0.30, "old_run", False),
+        ])
+        current_summary = {
+            "next": {"f1": {"mean": 0.25, "std": 0.01}},
+        }
+
+        result = save_best_record(tmp_path, comparison, current_summary, "new_run")
+
+        assert result is None
+        assert not (tmp_path / "best_record.json").exists()
 
     def test_updates_existing_record(self, tmp_path):
         # Pre-existing record.

--- a/tests/test_training/test_mtl_eval.py
+++ b/tests/test_training/test_mtl_eval.py
@@ -1,0 +1,146 @@
+"""Contract tests for ``training.runners.mtl_eval.evaluate_model``.
+
+Focuses on the post-review regression: the MTL validation pass must return
+per-task losses inside the per-task metric dicts so ``mtl_cv.py`` can
+forward them to ``fold_history.log_val('next', **metrics, ...)`` without
+hand-wiring ``loss=...``. Previously the per-task stores recorded
+``loss=0`` for every epoch, which silently stripped the validation loss
+signal from ``fold{i}_{task}_val.csv``.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from training.runners.mtl_eval import evaluate_model
+
+
+class _FakeMTL(nn.Module):
+    """Minimal two-head model mimicking MTLnet's forward signature."""
+
+    def __init__(self, embed_dim: int = 4, num_classes: int = 3) -> None:
+        super().__init__()
+        self.num_classes = num_classes
+        self.cat_head = nn.Linear(embed_dim, num_classes)
+        # Next head eats sequences; flatten inside forward to keep the
+        # test plumbing trivial.
+        self.next_head = nn.Linear(embed_dim, num_classes)
+
+    def forward(self, inputs):
+        x_cat, x_next = inputs
+        if x_next.ndim == 3:
+            x_next = x_next.mean(dim=1)  # collapse sequence dim
+        return self.cat_head(x_cat), self.next_head(x_next)
+
+
+def _make_loader(n: int, shape, num_classes: int, seed: int):
+    g = torch.Generator().manual_seed(seed)
+    x = torch.randn(n, *shape, generator=g)
+    y = torch.randint(0, num_classes, (n,), generator=g)
+    return torch.utils.data.DataLoader(
+        list(zip(x, y)), batch_size=4, shuffle=False
+    )
+
+
+class TestEvaluateModelContract:
+
+    @pytest.fixture
+    def setup(self):
+        torch.manual_seed(0)
+        embed_dim = 4
+        num_classes = 3
+        model = _FakeMTL(embed_dim=embed_dim, num_classes=num_classes)
+        model.eval()
+
+        cat_loader = _make_loader(16, (embed_dim,), num_classes, seed=1)
+        next_loader = _make_loader(12, (2, embed_dim), num_classes, seed=2)
+
+        criterion = nn.CrossEntropyLoss()
+        return model, [next_loader, cat_loader], criterion
+
+    def test_per_task_loss_is_inside_metric_dict(self, setup):
+        model, loaders, criterion = setup
+        metrics_next, metrics_cat, loss_combined = evaluate_model(
+            model, loaders, criterion, criterion, None, torch.device("cpu"),
+        )
+
+        # Per-task loss keys present and strictly positive (cross-entropy
+        # on random weights can't be zero on non-empty batches).
+        assert "loss" in metrics_next
+        assert "loss" in metrics_cat
+        assert metrics_next["loss"] > 0.0
+        assert metrics_cat["loss"] > 0.0
+
+    def test_combined_loss_is_mean_of_per_task_losses(self, setup):
+        model, loaders, criterion = setup
+        metrics_next, metrics_cat, loss_combined = evaluate_model(
+            model, loaders, criterion, criterion, None, torch.device("cpu"),
+        )
+        # combined_loss = mean over batches of (next + cat) / 2.
+        # When both running sums share the same denominator that reduces
+        # to the same as (mean(next) + mean(cat)) / 2.
+        expected = (metrics_next["loss"] + metrics_cat["loss"]) / 2
+        assert loss_combined == pytest.approx(expected, rel=1e-6)
+
+    def test_metric_dict_contains_classification_keys(self, setup):
+        model, loaders, criterion = setup
+        metrics_next, metrics_cat, _ = evaluate_model(
+            model, loaders, criterion, criterion, None, torch.device("cpu"),
+        )
+        for d in (metrics_next, metrics_cat):
+            for key in ("loss", "accuracy", "accuracy_macro", "f1",
+                        "f1_weighted", "mrr", "top3_acc", "ndcg_3"):
+                assert key in d, f"missing {key}"
+                assert isinstance(d[key], float)
+
+
+class TestTrainFallbackSchemaStability:
+    """Regression: ``_single_task_train``'s ``compute_train_f1=False``
+    fallback must still emit an ``f1`` key (=0.0) so
+    ``fold{i}_{task}_train.csv`` columns stay stable across runs with and
+    without ``compute_train_f1``."""
+
+    def test_fallback_train_store_has_f1_key(self):
+        from training.runners._single_task_train import train_single_task
+        from tracking.fold import FoldHistory
+
+        torch.manual_seed(0)
+        embed_dim = 4
+        num_classes = 3
+        model = nn.Linear(embed_dim, num_classes)
+        criterion = nn.CrossEntropyLoss()
+        optimizer = torch.optim.SGD(model.parameters(), lr=1e-2)
+
+        train_loader = _make_loader(16, (embed_dim,), num_classes, seed=3)
+        val_loader = _make_loader(8, (embed_dim,), num_classes, seed=4)
+
+        fold = FoldHistory.standalone(tasks={"next"})
+        fold.start()
+
+        train_single_task(
+            model=model,
+            train_loader=train_loader,
+            val_loader=val_loader,
+            criterion=criterion,
+            optimizer=optimizer,
+            scheduler=None,
+            device=torch.device("cpu"),
+            history=fold,
+            task_name="next",
+            num_classes=num_classes,
+            epochs=1,
+            compute_train_f1=False,  # exercise the fallback branch
+        )
+        fold.end()
+
+        train_keys = set(fold.task("next").train.keys())
+        assert "f1" in train_keys, (
+            "compute_train_f1=False must still log f1 (as 0.0) for CSV "
+            f"schema stability; got keys={train_keys}"
+        )
+        assert "accuracy" in train_keys
+        assert "loss" in train_keys
+        # And f1 is exactly 0.0 when compute_train_f1 is off.
+        assert fold.task("next").train["f1"] == [0.0]


### PR DESCRIPTION
## Summary

- Motivated by `docs/LITERATURE_SURVEY_POI_METRICS.md` and `docs/POI_RELATED_WORK_METRICS.md`, which both recommend keeping Macro-F1 + per-class P/R/F1 + Accuracy as primary metrics and *optionally* adding Weighted F1, Top-K Accuracy, MRR and NDCG@K as bridge metrics to the next-POI recommendation literature.
- New pure function `src/tracking/metrics.py::compute_classification_metrics(logits, targets, num_classes, top_k, prefix)` returns a flat `dict[str, float]` covering all of the above in one pass. The `'f1'` key is byte-identical to the previous `multiclass_f1_score(..., average='macro')` value so `BestModelTracker(monitor='f1')` stays compatible and NashMTL tuning history remains comparable.
- Consolidates the three validation sites (`mtl_eval.py`, `_single_task_train.py`, `mtl_cv.py` training epoch) to preserve logits through one call instead of duplicating four `torchmetrics` calls each. `training/evaluate.py::collect_predictions` now returns `(preds, targets, logits)` so `scripts/evaluate.py` can report ranking metrics alongside the sklearn `classification_report`.
- Tracking cleanup: `storage.py::_save_reports` now exports every val `MetricStore` key at the best epoch (new `metrics` block in `fold_info.json`, legacy `f1`/`accuracy` top-level keys preserved); `display.py::HistoryDisplay.end_fold` iterates a configurable `headline_metrics` tuple instead of hardcoding `('f1','accuracy')`. `_save_plots` and `_collect_performance` already auto-discovered keys — no change needed.

## Metrics added

| Key | Definition | Source |
|---|---|---|
| `accuracy` | micro accuracy (top-1) | `multiclass_accuracy(average='micro')` — unchanged |
| `accuracy_macro` | balanced accuracy | `multiclass_accuracy(average='macro')` |
| `f1` | macro F1 | `multiclass_f1_score(average='macro')` — unchanged |
| `f1_weighted` | weighted F1 | `multiclass_f1_score(average='weighted')` |
| `top{k}_acc` | Top-K accuracy, k in (3, 5) | torchmetrics `multiclass_accuracy(top_k=k)` |
| `mrr` | mean reciprocal rank over the full class ranking | hand-rolled |
| `ndcg_{k}` | NDCG@K with single-relevant-item binary relevance | hand-rolled |

## Numerical equivalence — three checks

1. **Pre/post refactor** — `f1` and `accuracy` byte-identical (diff = `0.0`) between old argmax-based path and new logits path on a 4096×7 synthetic batch. Holds because torchmetrics applies `argmax(dim=1)` internally for 2-D input.
2. **Closed-form MRR/NDCG/top-k** — Hand-computed on a 4-class, 4-sample case with known ranks `[2, 1, 4, 2]`. All ranking metrics match to machine precision.
3. **End-to-end smoke run** — `dgi + alabama` MTL, 3 epochs, 1 fold: sensible metric ordering holds (`top5_acc > top3_acc > accuracy`, `f1_weighted > f1` under class imbalance, `accuracy_macro < accuracy` under imbalance). Auto-generates 10 plots per task.

## Test plan

- [x] `pytest tests/test_tracking/test_metrics.py` — 12 unit tests (perfect/worst predictions, known-rank MRR/NDCG, imbalanced weighted-vs-macro, prefix, empty batch, single sample, top-k clamping, shape validation, Python float return type)
- [x] `pytest tests/test_tracking/` — 92 tests including new `TestIntegrationNewMetrics` asserting new keys flow through `MetricStore` → `fold_info.json` → plots
- [x] `pytest tests/test_training/ tests/test_regression/ tests/test_integration/ tests/test_models/` — all green
- [x] Full suite: **500 passed, 84 skipped, 0 failures**
- [x] Smoke run `scripts/train.py --task mtl --state alabama --engine dgi --epochs 3 --folds 1` — clean exit, all new metrics in `fold1_{next,category}_val.csv`, `folds/fold1_info.json`, `summary/full_summary.json`, and `plots/{task}/*.png`

## What is *not* changed

- `BestModelTracker` still monitors a single metric (`'f1'`). Revisiting multi-metric best-tracking is a separate decision.
- `classification_report` stays as the per-class P/R/F1 source of truth.
- `NashMTL`, optimizer, and loss wiring untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)