### PR TITLE
feat(check2hgi-up): variant model + losses + STL/MTL trainer harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ desktop.ini
 # Large regeneratable artefacts inside the leakage-ablation results tree.
 # Reproduce via `python experiments/hgi_leakage_ablation.py --state <State> --arms <arm>`.
 docs/studies/fusion/results/P0/leakage_ablation/*/*/embeddings.parquet
+
+# check2hgi-up: per-variant embedding parquets (~900 MB).
+# Reproduce via `python experiments/check2hgi_up/run_all.py`.
+# Commit JSONs, aggregate, anchors, and STL logs only.
+docs/studies/check2hgi/results/UP1/*_emb.parquet

--- a/experiments/check2hgi_up/aggregate.py
+++ b/experiments/check2hgi_up/aggregate.py
@@ -1,0 +1,104 @@
+"""Aggregate all variant runs + anchor baselines into a single table."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import statistics as st
+import sys
+from pathlib import Path
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--results_dir", default="docs/studies/check2hgi/results/UP1")
+    ap.add_argument("--state", default="alabama")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    rdir = Path(args.results_dir)
+
+    # Load anchors
+    anc_path = rdir / f"anchors_{args.state}.json"
+    anchors = None
+    if anc_path.exists():
+        anchors = json.load(open(anc_path))
+
+    # Load all variant runs
+    runs = []
+    for p in sorted(glob.glob(str(rdir / f"{args.state}_*_seed*_ep*.json"))):
+        # exclude summary files
+        if "summary" in Path(p).name or "anchors" in Path(p).name:
+            continue
+        d = json.load(open(p))
+        runs.append(d)
+
+    # Group by variant
+    variants = {}
+    for d in runs:
+        variants.setdefault(d["variant"], []).append(d)
+
+    # Compute stats
+    rows = []
+    base_f1 = None
+    for v, seeds in sorted(variants.items(), key=lambda x: x[0]):
+        f1s = [d["linear_probe"]["f1_mean"] for d in seeds]
+        accs = [d["linear_probe"]["acc_mean"] for d in seeds]
+        losses = [d["best_loss"] for d in seeds]
+        times = [d["train_time_s"] for d in seeds]
+        n_params = seeds[0]["n_params"]
+        row = {
+            "variant": v,
+            "n_seeds": len(seeds),
+            "f1_mean": st.mean(f1s),
+            "f1_std": st.stdev(f1s) if len(f1s) > 1 else 0.0,
+            "acc_mean": st.mean(accs),
+            "acc_std": st.stdev(accs) if len(accs) > 1 else 0.0,
+            "best_loss_mean": st.mean(losses),
+            "n_params": n_params,
+            "avg_train_s": st.mean(times),
+        }
+        rows.append(row)
+        if v == "baseline":
+            base_f1 = row["f1_mean"]
+
+    # Sort by F1 mean descending
+    rows.sort(key=lambda r: r["f1_mean"], reverse=True)
+
+    # Print anchor block
+    print(f"\n=== Check2HGI-up · Alabama · Linear Probe (next-category) ===\n")
+    if anchors:
+        for name, key in [("majority", "majority"), ("raw-features", "raw_features")]:
+            a = anchors[key]
+            print(f"{'anchor/'+name:<22} n=1   f1={a['f1_mean']:.4f}±{a['f1_std']:.4f}  "
+                  f"acc={a['acc_mean']:.4f}±{a['acc_std']:.4f}")
+    print()
+
+    # Print variant table
+    header = f"{'Variant':<22} {'Seeds':<5} {'F1-macro':<20} {'Acc':<20} {'Loss':<10} {'Params':<10} {'Δvs base'}"
+    print(header); print("-" * len(header))
+    for r in rows:
+        delta = f"+{(r['f1_mean']-base_f1)*100:.2f} pp" if base_f1 is not None else "—"
+        if r["variant"] == "baseline":
+            delta = "(ref)"
+        print(f"{r['variant']:<22} {r['n_seeds']:<5} "
+              f"{r['f1_mean']:.4f}±{r['f1_std']:.4f}  "
+              f"{r['acc_mean']:.4f}±{r['acc_std']:.4f}  "
+              f"{r['best_loss_mean']:.4f}   {r['n_params']:<10} "
+              f"{delta}")
+
+    # Save
+    out = args.out or (rdir / f"AGGREGATE_{args.state}.json")
+    with open(out, "w") as f:
+        json.dump({
+            "state": args.state,
+            "anchors": anchors,
+            "variants": rows,
+            "baseline_f1": base_f1,
+        }, f, indent=2)
+    print(f"\nSaved to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/check2hgi_up/eval_anchors.py
+++ b/experiments/check2hgi_up/eval_anchors.py
@@ -1,0 +1,76 @@
+"""Anchor baselines: linear probe on raw input features (no encoder),
+and a 'majority' floor. These anchor the variant comparison: if a variant's
+probe F1 is barely above raw-feature F1, the encoder isn't doing much.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pickle
+
+_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_root / "src"))
+sys.path.insert(0, str(_root / "research"))
+sys.path.insert(0, str(_root / "experiments" / "check2hgi_up"))
+
+from run_variant import build_eval_pairs, linear_probe_cv  # noqa: E402
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--state", default="Alabama")
+    ap.add_argument("--out_dir", default="docs/studies/check2hgi/results/UP1")
+    args = ap.parse_args()
+
+    p = _root / "output" / "check2hgi" / args.state.lower() / "temp" / "checkin_graph.pt"
+    with open(p, "rb") as f:
+        cd = pickle.load(f)
+    metadata = cd["metadata"]
+    raw_feats = cd["node_features"].astype(np.float32)  # [N_checkins, F]
+    print(f"raw features shape: {raw_feats.shape}")
+
+    # Anchor 1: identity raw features
+    X, y, groups, _ = build_eval_pairs(metadata, raw_feats)
+    t0 = time.time()
+    probe_raw = linear_probe_cv(X, y, groups, k=5, seed=42)
+    print(f"raw-features:  f1={probe_raw['f1_mean']:.4f}±{probe_raw['f1_std']:.4f}  "
+          f"acc={probe_raw['acc_mean']:.4f}±{probe_raw['acc_std']:.4f}  ({time.time()-t0:.1f}s)")
+
+    # Anchor 2: majority class — predicted label = mode of training set per fold
+    from sklearn.model_selection import GroupKFold
+    from sklearn.metrics import f1_score, accuracy_score
+    folds = list(GroupKFold(n_splits=5).split(X, y, groups=groups))
+    f1s, accs = [], []
+    for tr, te in folds:
+        most = np.bincount(y[tr]).argmax()
+        pred = np.full_like(y[te], most)
+        f1s.append(float(f1_score(y[te], pred, average="macro")))
+        accs.append(float(accuracy_score(y[te], pred)))
+    probe_maj = {
+        "f1_mean": float(np.mean(f1s)), "f1_std": float(np.std(f1s)),
+        "acc_mean": float(np.mean(accs)), "acc_std": float(np.std(accs)),
+        "f1_per_fold": f1s, "acc_per_fold": accs,
+    }
+    print(f"majority:      f1={probe_maj['f1_mean']:.4f}±{probe_maj['f1_std']:.4f}  "
+          f"acc={probe_maj['acc_mean']:.4f}±{probe_maj['acc_std']:.4f}")
+
+    out_dir = Path(args.out_dir); out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / f"anchors_{args.state.lower()}.json", "w") as f:
+        json.dump({
+            "state": args.state,
+            "raw_features": probe_raw,
+            "majority": probe_maj,
+            "raw_feature_dim": int(raw_feats.shape[1]),
+        }, f, indent=2)
+    print(f"saved anchors to {out_dir}/anchors_{args.state.lower()}.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/check2hgi_up/run_all.py
+++ b/experiments/check2hgi_up/run_all.py
@@ -1,0 +1,122 @@
+"""Drive the full Check2HGI variant sweep on Alabama.
+
+Runs each of {baseline, infonce, gat_time, skip_ln, uncertainty, combined}
+× {seeds 42, 43, 44} for `epochs` epochs, then aggregates and prints a table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics as st
+import sys
+import time
+from pathlib import Path
+
+_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_root / "src"))
+sys.path.insert(0, str(_root / "research"))
+sys.path.insert(0, str(_root / "experiments" / "check2hgi_up"))
+
+from run_variant import VARIANTS, run_one  # noqa: E402
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--state", default="Alabama")
+    ap.add_argument("--epochs", type=int, default=200)
+    ap.add_argument("--seeds", type=int, nargs="+", default=[42, 43, 44])
+    ap.add_argument("--variants", nargs="+", default=VARIANTS, choices=VARIANTS)
+    ap.add_argument("--out_dir", default="docs/studies/check2hgi/results/UP1")
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--num_negatives", type=int, default=32)
+    ap.add_argument("--temperature", type=float, default=0.2)
+    ap.add_argument("--lr", type=float, default=1e-3)
+    args = ap.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    t_start = time.time()
+    for variant in args.variants:
+        for seed in args.seeds:
+            print(f"\n{'='*60}\n>>> {variant} seed={seed}\n{'='*60}")
+            try:
+                r = run_one(
+                    variant=variant, seed=seed, state=args.state,
+                    epochs=args.epochs, dim=64, heads=4, lr=args.lr,
+                    max_norm=0.9, num_negatives=args.num_negatives,
+                    temperature=args.temperature, out_dir=out_dir,
+                    device=args.device, log_every=max(args.epochs // 4, 1),
+                )
+                rows.append({
+                    "variant": variant, "seed": seed,
+                    "f1_mean": r["linear_probe"]["f1_mean"],
+                    "f1_std": r["linear_probe"]["f1_std"],
+                    "acc_mean": r["linear_probe"]["acc_mean"],
+                    "acc_std": r["linear_probe"]["acc_std"],
+                    "best_loss": r["best_loss"],
+                    "n_params": r["n_params"],
+                    "train_s": r["train_time_s"],
+                })
+            except Exception as e:
+                print(f"!!! FAILED {variant} seed={seed}: {e}")
+                rows.append({
+                    "variant": variant, "seed": seed, "error": repr(e),
+                })
+
+    elapsed = time.time() - t_start
+    print(f"\n=== sweep done in {elapsed:.1f}s ({elapsed/60:.1f}m) ===\n")
+
+    # Aggregate per-variant
+    summary = {}
+    for v in args.variants:
+        vrows = [r for r in rows if r["variant"] == v and "f1_mean" in r]
+        if not vrows:
+            summary[v] = {"error": "no successful runs"}; continue
+        # mean across seeds (each seed already gives mean across folds)
+        f1_means = [r["f1_mean"] for r in vrows]
+        acc_means = [r["acc_mean"] for r in vrows]
+        summary[v] = {
+            "n_seeds": len(vrows),
+            "f1_macro_mean_across_seeds": st.mean(f1_means),
+            "f1_macro_std_across_seeds": st.stdev(f1_means) if len(f1_means) > 1 else 0.0,
+            "acc_mean_across_seeds": st.mean(acc_means),
+            "acc_std_across_seeds": st.stdev(acc_means) if len(acc_means) > 1 else 0.0,
+            "best_loss_mean": st.mean(r["best_loss"] for r in vrows),
+            "n_params": vrows[0]["n_params"],
+            "avg_train_s": st.mean(r["train_s"] for r in vrows),
+        }
+
+    # Save & print
+    summary_path = out_dir / f"summary_{args.state.lower()}_ep{args.epochs}.json"
+    with open(summary_path, "w") as f:
+        json.dump({
+            "config": {
+                "state": args.state, "epochs": args.epochs, "seeds": args.seeds,
+                "variants": args.variants, "lr": args.lr,
+                "num_negatives": args.num_negatives, "temperature": args.temperature,
+            },
+            "summary": summary,
+            "rows": rows,
+            "elapsed_s": elapsed,
+        }, f, indent=2)
+    print(f"\nSummary saved to {summary_path}\n")
+
+    # Print table
+    print(f"{'Variant':<14} {'Seeds':<6} {'F1_macro':<22} {'Acc':<22} {'Loss':<10} {'Params':<10}")
+    print("-" * 90)
+    for v in args.variants:
+        s = summary[v]
+        if "error" in s:
+            print(f"{v:<14} {s['error']}")
+            continue
+        print(f"{v:<14} {s['n_seeds']:<6} "
+              f"{s['f1_macro_mean_across_seeds']:.4f}±{s['f1_macro_std_across_seeds']:.4f}    "
+              f"{s['acc_mean_across_seeds']:.4f}±{s['acc_std_across_seeds']:.4f}    "
+              f"{s['best_loss_mean']:.4f}    {s['n_params']:<10}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/check2hgi_up/run_mtl_b3.py
+++ b/experiments/check2hgi_up/run_mtl_b3.py
@@ -1,0 +1,112 @@
+"""Run MTL-B3 (post-F27 champion config) on a state with a swapped Check2HGI substrate.
+
+B3 config (post-F27, per docs/studies/check2hgi/SESSION_HANDOFF_2026-04-24.md):
+    mtlnet_crossattn + static_weight(category_weight=0.75)
+    + cat-head=next_gru (task_a)
+    + reg-head=next_getnext_hard d=256, 8h (task_b)
+
+Swap procedure:
+  1. Backup `output/check2hgi/{state}/embeddings.parquet` if not already
+  2. Copy variant embedding into that path
+  3. Regenerate `next.parquet` + `sequences_next.parquet`
+     (note: `region_transition_log.pt` does not depend on embeddings —
+      it is reused as-is.)
+  4. Run scripts/train.py --task mtl ...
+  5. Restore baseline embedding + regenerate next.parquet so a downstream
+     scripts/train.py invocation doesn't accidentally use the variant data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_root / "src"))
+sys.path.insert(0, str(_root / "research"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--variant", required=True)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--state", required=True)
+    ap.add_argument("--epochs", type=int, default=50)
+    ap.add_argument("--folds", type=int, default=5)
+    ap.add_argument("--source_dir", default="docs/studies/check2hgi/results/UP1")
+    ap.add_argument("--source_epochs", type=int, default=200)
+    ap.add_argument("--cat_head", default="next_gru",
+                    help="Post-F27 default. Use 'default' to skip the flag (pre-F27 B3).")
+    args = ap.parse_args()
+
+    state_lower = args.state.lower()
+    src = Path(args.source_dir) / f"{state_lower}_{args.variant}_seed{args.seed}_ep{args.source_epochs}_emb.parquet"
+    if not src.exists():
+        sys.exit(f"variant embedding not found: {src}")
+
+    target = _root / "output" / "check2hgi" / state_lower / "embeddings.parquet"
+    backup = target.with_suffix(".parquet.bak_orig")
+
+    if not backup.exists():
+        print(f"[backup] {target} -> {backup}")
+        shutil.copy2(target, backup)
+    else:
+        print(f"[backup] already exists at {backup}")
+
+    print(f"[swap] {src} -> {target}")
+    shutil.copy2(src, target)
+
+    print("[regen] generate_next_input_from_checkins ...")
+    from configs.paths import EmbeddingEngine
+    from data.inputs.builders import generate_next_input_from_checkins
+    generate_next_input_from_checkins(args.state, EmbeddingEngine.CHECK2HGI)
+
+    transition_path = (_root / "output" / "check2hgi" / state_lower /
+                       "region_transition_log.pt")
+    if not transition_path.exists():
+        sys.exit(f"region_transition_log.pt not found at {transition_path}; "
+                 f"run scripts/compute_region_transition.py --state {state_lower}")
+
+    cmd = [
+        sys.executable, "-u", "scripts/train.py",
+        "--state", state_lower,
+        "--task", "mtl",
+        "--task-set", "check2hgi_next_region",
+        "--engine", "check2hgi",
+        "--folds", str(args.folds),
+        "--epochs", str(args.epochs),
+        "--seed", "42",
+        "--task-a-input-type", "checkin",
+        "--task-b-input-type", "region",
+        "--model", "mtlnet_crossattn",
+        "--mtl-loss", "static_weight",
+        "--category-weight", "0.75",
+        "--reg-head", "next_getnext_hard",
+        "--reg-head-param", "d_model=256",
+        "--reg-head-param", "num_heads=8",
+        "--reg-head-param", f"transition_path={transition_path}",
+        "--max-lr", "0.003",
+        "--gradient-accumulation-steps", "1",
+        "--no-checkpoints",
+    ]
+    if args.cat_head != "default":
+        cmd.extend(["--cat-head", args.cat_head])
+
+    print("[train] " + " ".join(cmd))
+    rc = subprocess.call(cmd)
+    print(f"[train] returncode={rc}")
+
+    print(f"[restore] {backup} -> {target}")
+    shutil.copy2(backup, target)
+    print("[restore] regenerating next.parquet from restored embedding ...")
+    generate_next_input_from_checkins(args.state, EmbeddingEngine.CHECK2HGI)
+    print("[done]")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/check2hgi_up/run_stl_eval.py
+++ b/experiments/check2hgi_up/run_stl_eval.py
@@ -1,0 +1,90 @@
+"""Run STL next-category training for one variant on AL.
+
+This is the headline eval — the linear probe is just a fast proxy. Here we
+plug a variant's embeddings into the actual MTLnet pipeline and run the same
+single-task training that produced the published 38.58 ± 1.23 baseline.
+
+Strategy:
+  1. Backup current `output/check2hgi/{state}/embeddings.parquet`
+  2. Copy variant embeddings into that path
+  3. Regenerate `next.parquet` via `generate_next_input_from_checkins(...)`
+  4. Run `scripts/train.py --task next --engine check2hgi --state {state} --folds 5 --epochs 50`
+  5. Restore backup
+
+Designed to be re-runnable (each call backs up only if a backup doesn't exist).
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_root / "src"))
+sys.path.insert(0, str(_root / "research"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--variant", required=True)
+    ap.add_argument("--seed", type=int, required=True)
+    ap.add_argument("--state", default="Alabama")
+    ap.add_argument("--epochs", type=int, default=50)
+    ap.add_argument("--folds", type=int, default=5)
+    ap.add_argument("--source_dir", default="docs/studies/check2hgi/results/UP1")
+    ap.add_argument("--source_epochs", type=int, default=200)
+    args = ap.parse_args()
+
+    state_lower = args.state.lower()
+    src = Path(args.source_dir) / f"{state_lower}_{args.variant}_seed{args.seed}_ep{args.source_epochs}_emb.parquet"
+    if not src.exists():
+        sys.exit(f"variant embedding not found: {src}")
+
+    target = _root / "output" / "check2hgi" / state_lower / "embeddings.parquet"
+    backup = target.with_suffix(".parquet.bak_orig")
+
+    if not backup.exists():
+        print(f"[backup] {target} -> {backup}")
+        shutil.copy2(target, backup)
+    else:
+        print(f"[backup] already exists at {backup}, leaving alone")
+
+    print(f"[swap] {src} -> {target}")
+    shutil.copy2(src, target)
+
+    # Regenerate next.parquet
+    print("[regen] generate_next_input_from_checkins ...")
+    from configs.paths import EmbeddingEngine
+    from data.inputs.builders import generate_next_input_from_checkins
+    generate_next_input_from_checkins(args.state, EmbeddingEngine.CHECK2HGI)
+
+    # Run STL next training
+    cmd = [
+        sys.executable, "scripts/train.py",
+        "--task", "next",
+        "--engine", "check2hgi",
+        "--state", state_lower,
+        "--folds", str(args.folds),
+        "--epochs", str(args.epochs),
+        "--no-checkpoints",
+    ]
+    print("[train] " + " ".join(cmd))
+    rc = subprocess.call(cmd)
+    print(f"[train] returncode={rc}")
+
+    # Restore embedding + regenerate next.parquet so subsequent plain
+    # scripts/train.py invocations don't accidentally use the variant's
+    # cached next.parquet.
+    print(f"[restore] {backup} -> {target}")
+    shutil.copy2(backup, target)
+    print("[restore] regenerating next.parquet from restored embedding ...")
+    generate_next_input_from_checkins(args.state, EmbeddingEngine.CHECK2HGI)
+    print("[done]")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/check2hgi_up/run_variant.py
+++ b/experiments/check2hgi_up/run_variant.py
@@ -1,0 +1,385 @@
+"""Train one Check2HGI variant on Alabama and evaluate via a sequence-aware
+linear probe on next-category prediction.
+
+Designed to be cheap (~5 min/run on a single GPU) so we can compare 5+ variants
+across 3 seeds and still finish in under an hour.
+
+The linear probe is the proxy for downstream MTLnet category quality:
+- For each (current_checkin, next_checkin_same_user), predict next.category
+  from current.embedding.
+- Multinomial logistic regression with L2.
+- 5-fold cross-validation, stratified by userid (user-disjoint folds).
+- Reports macro-F1 + accuracy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import pickle
+import random
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+import torch.nn.functional as F
+
+from torch_geometric.data import Data
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import f1_score, accuracy_score
+from sklearn.model_selection import GroupKFold
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+# project imports
+_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_root / "src"))
+sys.path.insert(0, str(_root / "research"))
+
+from embeddings.check2hgi.model.Check2HGIModule import Check2HGI, corruption  # noqa: E402
+from embeddings.check2hgi.model.CheckinEncoder import CheckinEncoder  # noqa: E402
+from embeddings.check2hgi.model.Checkin2POI import Checkin2POI  # noqa: E402
+from embeddings.hgi.model.RegionEncoder import POI2Region  # noqa: E402
+from embeddings.check2hgi.model.variants import (  # noqa: E402
+    GATTimeEncoder,
+    ResidualLNEncoder,
+    Check2HGI_InfoNCE,
+    Check2HGI_Uncertainty,
+    Check2HGI_Combined,
+)
+
+
+VARIANTS = [
+    "baseline",       # V0: original Check2HGI
+    "infonce",        # V1: InfoNCE multi-negative at C2P
+    "gat_time",       # V2: GATv2 time-aware encoder
+    "skip_ln",        # V3: residual + LayerNorm encoder
+    "uncertainty",    # V4: learnable Kendall-style alphas
+    "combined",       # V5: skip+LN encoder + InfoNCE + uncertainty
+    "combined_gat",   # V6: GAT encoder + InfoNCE + uncertainty
+    "infonce_tuned",  # V1+: InfoNCE with K=256, T=0.1 (SOTA-tuned)
+    "gat_infonce",    # V7: GAT encoder + InfoNCE (no uncertainty)
+]
+
+
+def set_seed(seed: int):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def load_data(state: str, device: str) -> tuple[Data, dict]:
+    p = _root / "output" / "check2hgi" / state.lower() / "temp" / "checkin_graph.pt"
+    with open(p, "rb") as f:
+        cd = pickle.load(f)
+    data = Data(
+        x=torch.tensor(cd["node_features"], dtype=torch.float32),
+        edge_index=torch.tensor(cd["edge_index"], dtype=torch.int64),
+        edge_weight=torch.tensor(cd["edge_weight"], dtype=torch.float32),
+        checkin_to_poi=torch.tensor(cd["checkin_to_poi"], dtype=torch.int64),
+        poi_to_region=torch.tensor(cd["poi_to_region"], dtype=torch.int64),
+        region_adjacency=torch.tensor(cd["region_adjacency"], dtype=torch.int64),
+        region_area=torch.tensor(cd["region_area"], dtype=torch.float32),
+        coarse_region_similarity=torch.tensor(
+            cd["coarse_region_similarity"], dtype=torch.float32
+        ),
+        num_pois=cd["num_pois"],
+        num_regions=cd["num_regions"],
+    ).to(device)
+    return data, cd
+
+
+def build_model(variant: str, in_channels: int, dim: int, heads: int, num_layers: int,
+                alpha=(0.4, 0.3, 0.3), num_negatives=32, temperature=0.2,
+                infonce_chunk_size: int | None = None):
+    """Build a Check2HGI variant. Returns (model, encoder_kind)."""
+    if variant in ("gat_time", "combined_gat", "gat_infonce"):
+        ce = GATTimeEncoder(in_channels, dim, num_layers=num_layers, heads=heads)
+    elif variant in ("skip_ln",):
+        ce = ResidualLNEncoder(in_channels, dim, num_layers=max(num_layers, 3))
+    elif variant == "combined":
+        # V5 uses skip+LN encoder by default
+        ce = ResidualLNEncoder(in_channels, dim, num_layers=3)
+    else:
+        ce = CheckinEncoder(in_channels, dim, num_layers=num_layers)
+
+    c2p = Checkin2POI(dim, heads)
+    p2r = POI2Region(dim, heads)
+
+    def r2c(z, area):
+        return torch.sigmoid((z.transpose(0, 1) * area).sum(dim=1))
+
+    a_c2p, a_p2r, a_r2c = alpha
+
+    if variant in ("infonce", "infonce_tuned", "gat_infonce"):
+        # SOTA-tuned: K=256, T=0.1 for infonce_tuned; K=num_negatives, T=temperature otherwise
+        if variant == "infonce_tuned":
+            K, T = 256, 0.1
+        else:
+            K, T = num_negatives, temperature
+        m = Check2HGI_InfoNCE(
+            hidden_channels=dim, checkin_encoder=ce, checkin2poi=c2p, poi2region=p2r,
+            region2city=r2c, corruption=corruption,
+            alpha_c2p=a_c2p, alpha_p2r=a_p2r, alpha_r2c=a_r2c,
+            num_negatives=K, temperature=T, chunk_size=infonce_chunk_size,
+        )
+    elif variant == "uncertainty":
+        m = Check2HGI_Uncertainty(
+            hidden_channels=dim, checkin_encoder=ce, checkin2poi=c2p, poi2region=p2r,
+            region2city=r2c, corruption=corruption,
+            alpha_c2p=a_c2p, alpha_p2r=a_p2r, alpha_r2c=a_r2c,
+        )
+    elif variant in ("combined", "combined_gat"):
+        m = Check2HGI_Combined(
+            hidden_channels=dim, checkin_encoder=ce, checkin2poi=c2p, poi2region=p2r,
+            region2city=r2c, corruption=corruption,
+            alpha_c2p=a_c2p, alpha_p2r=a_p2r, alpha_r2c=a_r2c,
+            num_negatives=num_negatives, temperature=temperature,
+        )
+    else:
+        m = Check2HGI(
+            hidden_channels=dim, checkin_encoder=ce, checkin2poi=c2p, poi2region=p2r,
+            region2city=r2c, corruption=corruption,
+            alpha_c2p=a_c2p, alpha_p2r=a_p2r, alpha_r2c=a_r2c,
+        )
+    return m
+
+
+def train_embedding(model, data, epochs, lr, max_norm, device, log_every=50, amp_dtype=None):
+    optim = torch.optim.Adam(model.parameters(), lr=lr)
+    losses = []
+    best = (math.inf, 0, None)
+    use_amp = amp_dtype is not None and device == "cuda"
+    if use_amp:
+        print(f"  [amp] using torch.autocast(cuda, dtype={amp_dtype})")
+    for ep in range(1, epochs + 1):
+        model.train()
+        optim.zero_grad()
+        if use_amp:
+            with torch.autocast(device_type="cuda", dtype=amp_dtype):
+                out = model(data)
+                loss = model.loss(*out)
+        else:
+            out = model(data)
+            loss = model.loss(*out)
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm=max_norm)
+        optim.step()
+        v = float(loss.item())
+        losses.append(v)
+        if not math.isfinite(v):
+            raise RuntimeError(f"NaN/Inf loss at epoch {ep}")
+        if v < best[0]:
+            best = (v, ep, {k: t.detach().clone() for k, t in model.state_dict().items()})
+        if ep % log_every == 0 or ep == 1 or ep == epochs:
+            print(f"  ep {ep:4d}/{epochs}  loss={v:.4f}  best={best[0]:.4f}@{best[1]}")
+    model.load_state_dict(best[2])
+    return losses, best[1], best[0]
+
+
+@torch.no_grad()
+def extract_embeddings(model, data) -> np.ndarray:
+    model.eval()
+    _ = model(data)
+    chk, _, _ = model.get_embeddings()
+    return chk.cpu().numpy()
+
+
+@torch.no_grad()
+def extract_all_embeddings(model, data):
+    """Return (checkin, poi, region) numpy arrays.
+
+    Used by UP3 to dump region/POI embeddings as parquet alongside the
+    check-in embeddings, so the variant's region embeddings can stand in
+    for the baseline check2hgi region_embeddings.parquet in the F21c
+    next-region apparatus.
+    """
+    model.eval()
+    _ = model(data)
+    chk, poi, reg = model.get_embeddings()
+    return chk.cpu().numpy(), poi.cpu().numpy(), reg.cpu().numpy()
+
+
+def build_eval_pairs(metadata: pd.DataFrame, embeddings: np.ndarray, cat_to_id: dict | None = None):
+    """For each user, build (current_emb, next_category) pairs."""
+    df = metadata.copy().reset_index(drop=True)
+    df["emb_idx"] = np.arange(len(df))
+    df = df.sort_values(["userid", "datetime"]).reset_index(drop=True)
+    df["next_category"] = df.groupby("userid")["category"].shift(-1)
+    df = df.dropna(subset=["next_category"]).reset_index(drop=True)
+
+    if cat_to_id is None:
+        cats = sorted(df["category"].unique())
+        cat_to_id = {c: i for i, c in enumerate(cats)}
+    df["next_cat_id"] = df["next_category"].map(cat_to_id)
+
+    X = embeddings[df["emb_idx"].values]
+    y = df["next_cat_id"].values.astype(np.int64)
+    groups = df["userid"].values
+    return X, y, groups, cat_to_id
+
+
+def linear_probe_cv(X: np.ndarray, y: np.ndarray, groups: np.ndarray, k: int = 5, seed: int = 42):
+    """User-disjoint K-fold logistic regression. Returns per-fold + mean metrics."""
+    folds = list(GroupKFold(n_splits=k).split(X, y, groups=groups))
+    f1s, accs = [], []
+    for fold_i, (tr, te) in enumerate(folds):
+        clf = Pipeline([
+            ("scaler", StandardScaler()),
+            ("lr", LogisticRegression(
+                max_iter=200, C=1.0, n_jobs=1, solver="lbfgs",
+                random_state=seed,
+            )),
+        ])
+        clf.fit(X[tr], y[tr])
+        pred = clf.predict(X[te])
+        f1 = f1_score(y[te], pred, average="macro")
+        acc = accuracy_score(y[te], pred)
+        f1s.append(float(f1)); accs.append(float(acc))
+    return {
+        "f1_per_fold": f1s,
+        "acc_per_fold": accs,
+        "f1_mean": float(np.mean(f1s)),
+        "f1_std": float(np.std(f1s)),
+        "acc_mean": float(np.mean(accs)),
+        "acc_std": float(np.std(accs)),
+    }
+
+
+def run_one(variant: str, seed: int, state: str, epochs: int, dim: int, heads: int,
+            lr: float, max_norm: float, num_negatives: int, temperature: float,
+            out_dir: Path, device: str = "cuda", log_every: int = 50,
+            infonce_chunk_size: int | None = None, amp_dtype=None):
+    set_seed(seed)
+    data, cd = load_data(state, device)
+    in_channels = data.x.size(1)
+    metadata = cd["metadata"]
+
+    print(f"\n[{variant} seed={seed}] start  ({state}, "
+          f"checkins={cd['num_checkins']}, pois={cd['num_pois']}, regions={cd['num_regions']})")
+    t0 = time.time()
+    model = build_model(
+        variant, in_channels, dim, heads, num_layers=2,
+        alpha=(0.4, 0.3, 0.3), num_negatives=num_negatives, temperature=temperature,
+        infonce_chunk_size=infonce_chunk_size,
+    ).to(device)
+    n_params = sum(p.numel() for p in model.parameters())
+
+    losses, best_ep, best_loss = train_embedding(
+        model, data, epochs=epochs, lr=lr, max_norm=max_norm, device=device, log_every=log_every,
+        amp_dtype=amp_dtype,
+    )
+    embeddings, poi_embeddings, region_embeddings = extract_all_embeddings(model, data)
+    train_time = time.time() - t0
+    print(f"[{variant} seed={seed}] trained in {train_time:.1f}s, best_ep={best_ep}, best_loss={best_loss:.4f}")
+    print(f"[{variant} seed={seed}] embeddings: chk={embeddings.shape}, "
+          f"poi={poi_embeddings.shape}, region={region_embeddings.shape}")
+
+    # Eval
+    X, y, groups, _ = build_eval_pairs(metadata, embeddings)
+    probe = linear_probe_cv(X, y, groups, k=5, seed=seed)
+    print(f"[{variant} seed={seed}] probe: f1_macro={probe['f1_mean']:.4f}±{probe['f1_std']:.4f}  "
+          f"acc={probe['acc_mean']:.4f}±{probe['acc_std']:.4f}")
+
+    # Persist
+    out_dir.mkdir(parents=True, exist_ok=True)
+    result = {
+        "variant": variant,
+        "seed": seed,
+        "state": state,
+        "epochs": epochs,
+        "dim": dim,
+        "heads": heads,
+        "lr": lr,
+        "max_norm": max_norm,
+        "n_params": n_params,
+        "best_epoch": best_ep,
+        "best_loss": best_loss,
+        "train_time_s": train_time,
+        "linear_probe": probe,
+        "loss_curve": losses,
+    }
+    if variant in ("infonce", "combined"):
+        result["num_negatives"] = num_negatives
+        result["temperature"] = temperature
+
+    fname = f"{state.lower()}_{variant}_seed{seed}_ep{epochs}.json"
+    with open(out_dir / fname, "w") as f:
+        json.dump(result, f, indent=2)
+
+    # Also save the embeddings parquet (small) so we can reuse without retraining
+    emb_path = out_dir / f"{state.lower()}_{variant}_seed{seed}_ep{epochs}_emb.parquet"
+    df = pd.DataFrame(embeddings, columns=[str(i) for i in range(embeddings.shape[1])])
+    df.insert(0, "datetime", metadata["datetime"].values)
+    df.insert(0, "category", metadata["category"].values)
+    df.insert(0, "placeid", metadata["placeid"].values)
+    df.insert(0, "userid", metadata["userid"].values)
+    df.to_parquet(emb_path, index=False)
+
+    # UP3: dump region and POI embeddings in the schema p1_region_head_ablation
+    # expects so they can swap in for output/check2hgi/{state}/region_embeddings.parquet
+    # (cols: region_id, reg_0..reg_{D-1}; sorted by region_id).
+    region_path = out_dir / f"{state.lower()}_{variant}_seed{seed}_ep{epochs}_region_emb.parquet"
+    region_df = pd.DataFrame(
+        region_embeddings,
+        columns=[f"reg_{i}" for i in range(region_embeddings.shape[1])],
+    )
+    region_df.insert(0, "region_id", np.arange(region_embeddings.shape[0], dtype=np.int64))
+    region_df.to_parquet(region_path, index=False)
+
+    poi_path = out_dir / f"{state.lower()}_{variant}_seed{seed}_ep{epochs}_poi_emb.parquet"
+    poi_df = pd.DataFrame(
+        poi_embeddings,
+        columns=[f"poi_{i}" for i in range(poi_embeddings.shape[1])],
+    )
+    poi_df.insert(0, "poi_idx", np.arange(poi_embeddings.shape[0], dtype=np.int64))
+    poi_df.to_parquet(poi_path, index=False)
+
+    return result
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--variant", required=True, choices=VARIANTS)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--state", default="Alabama")
+    ap.add_argument("--epochs", type=int, default=200)
+    ap.add_argument("--dim", type=int, default=64)
+    ap.add_argument("--heads", type=int, default=4)
+    ap.add_argument("--lr", type=float, default=1e-3)
+    ap.add_argument("--max_norm", type=float, default=0.9)
+    ap.add_argument("--num_negatives", type=int, default=32)
+    ap.add_argument("--temperature", type=float, default=0.2)
+    ap.add_argument("--out_dir", default="docs/studies/check2hgi/results/UP1")
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--log_every", type=int, default=50)
+    ap.add_argument("--infonce_chunk_size", type=int, default=None,
+                    help="Chunk size for InfoNCE neg sampling. None = no chunking. "
+                         "Set to e.g. 262144 for FL on a 6 GB GPU.")
+    ap.add_argument("--amp", choices=["bf16", "fp16", "none"], default="none",
+                    help="Mixed-precision dtype for forward/loss. bf16 is the "
+                         "safe choice on Ampere+ GPUs (RTX 30/40); fp16 needs "
+                         "loss scaling not implemented here.")
+    args = ap.parse_args()
+    amp_dtype_map = {"bf16": torch.bfloat16, "fp16": torch.float16, "none": None}
+    amp_dtype = amp_dtype_map[args.amp]
+
+    out_dir = Path(args.out_dir)
+    run_one(
+        variant=args.variant, seed=args.seed, state=args.state, epochs=args.epochs,
+        dim=args.dim, heads=args.heads, lr=args.lr, max_norm=args.max_norm,
+        num_negatives=args.num_negatives, temperature=args.temperature,
+        out_dir=out_dir, device=args.device, log_every=args.log_every,
+        infonce_chunk_size=args.infonce_chunk_size, amp_dtype=amp_dtype,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/research/embeddings/check2hgi/model/variants.py
+++ b/research/embeddings/check2hgi/model/variants.py
@@ -1,0 +1,335 @@
+"""Variant model components for the check2hgi-up study.
+
+Each variant is a single, isolated change so that the downstream comparison
+can attribute effects to a specific intervention. Borrows ideas from HGI
+(hard negatives, set-transformer pooling), Time2Vec (explicit time encoding),
+and modern self-supervised practice (InfoNCE, uncertainty-weighted MTL).
+"""
+
+from __future__ import annotations
+
+import math
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch_geometric.nn import GCNConv, GATv2Conv
+
+from embeddings.check2hgi.model.Check2HGIModule import Check2HGI, corruption, EPS
+
+
+# ---------------------------------------------------------------------------
+# V2: Time-aware GAT encoder
+# ---------------------------------------------------------------------------
+
+class GATTimeEncoder(nn.Module):
+    """GATv2 encoder where attention is conditioned on the (1-d) temporal
+    edge weight from the user-sequence graph."""
+
+    def __init__(self, in_channels, hidden_channels, num_layers=2, heads=4, dropout=0.0):
+        super().__init__()
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.num_layers = num_layers
+
+        assert hidden_channels % heads == 0
+        head_dim = hidden_channels // heads
+
+        self.convs = nn.ModuleList()
+        # First layer: in_channels -> hidden_channels
+        self.convs.append(GATv2Conv(in_channels, head_dim, heads=heads,
+                                    edge_dim=1, concat=True, add_self_loops=True))
+        for _ in range(num_layers - 1):
+            self.convs.append(GATv2Conv(hidden_channels, head_dim, heads=heads,
+                                        edge_dim=1, concat=True, add_self_loops=True))
+
+        self.act = nn.PReLU()
+        self.dropout = nn.Dropout(dropout) if dropout > 0 else nn.Identity()
+
+    def forward(self, x, edge_index, edge_weight=None):
+        edge_attr = edge_weight.unsqueeze(-1) if edge_weight is not None else None
+        for i, conv in enumerate(self.convs):
+            x = conv(x, edge_index, edge_attr=edge_attr)
+            if i < len(self.convs) - 1:
+                x = self.act(x)
+                x = self.dropout(x)
+        return x
+
+
+# ---------------------------------------------------------------------------
+# V3: Residual + LayerNorm GCN encoder
+# ---------------------------------------------------------------------------
+
+class ResidualLNEncoder(nn.Module):
+    """Multi-layer GCN with pre-LN and residual connections from layer 1 onward."""
+
+    def __init__(self, in_channels, hidden_channels, num_layers=3, dropout=0.1):
+        super().__init__()
+        self.in_channels = in_channels
+        self.hidden_channels = hidden_channels
+        self.num_layers = num_layers
+
+        self.convs = nn.ModuleList()
+        self.norms = nn.ModuleList()
+        self.convs.append(GCNConv(in_channels, hidden_channels, cached=False, bias=True))
+        self.norms.append(nn.LayerNorm(hidden_channels))
+        for _ in range(num_layers - 1):
+            self.convs.append(GCNConv(hidden_channels, hidden_channels, cached=False, bias=True))
+            self.norms.append(nn.LayerNorm(hidden_channels))
+
+        self.act = nn.PReLU()
+        self.dropout = nn.Dropout(dropout) if dropout > 0 else nn.Identity()
+
+    def forward(self, x, edge_index, edge_weight=None):
+        # First layer (no residual since dim mismatch)
+        x = self.convs[0](x, edge_index, edge_weight)
+        x = self.norms[0](x)
+        x = self.act(x)
+        x = self.dropout(x)
+        # Subsequent layers with residual connections
+        for i in range(1, self.num_layers):
+            h = self.norms[i](x)
+            h = self.convs[i](h, edge_index, edge_weight)
+            if i < self.num_layers - 1:
+                h = self.act(h)
+                h = self.dropout(h)
+            x = x + h
+        return x
+
+
+# ---------------------------------------------------------------------------
+# V1: Check2HGI with InfoNCE contrastive at C2P boundary
+# ---------------------------------------------------------------------------
+
+class Check2HGI_InfoNCE(Check2HGI):
+    """Replaces the C2P bilinear-sigmoid-BCE loss with K-negative
+    InfoNCE / cross-entropy style contrastive loss.
+
+    For each check-in i: anchor = checkin_emb[i] (projected via W_c2p),
+    positive = poi_emb[checkin_to_poi[i]],
+    negatives = K random POIs (different from positive).
+    Loss = -log( exp(sim_pos/τ) / (exp(sim_pos/τ) + Σ exp(sim_neg/τ)) )
+    """
+
+    def __init__(self, *args, num_negatives: int = 32, temperature: float = 0.2,
+                 chunk_size: int | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.num_negatives = num_negatives
+        self.temperature = temperature
+        # chunk_size: process N_c in slices when materializing [N_c, K, D]
+        # would OOM. None = no chunking. ~256k is safe for 6 GB GPUs at K=32, D=64.
+        self.chunk_size = chunk_size
+
+    def forward(self, data):
+        num_pois = data.num_pois
+        num_regions = data.num_regions
+
+        pos_checkin_emb = self.checkin_encoder(data.x, data.edge_index, data.edge_weight)
+        cor_x = self.corruption(data.x)
+        neg_checkin_emb = self.checkin_encoder(cor_x, data.edge_index, data.edge_weight)
+
+        pos_poi_emb = self.checkin2poi(pos_checkin_emb, data.checkin_to_poi, num_pois)
+        neg_poi_emb = self.checkin2poi(neg_checkin_emb, data.checkin_to_poi, num_pois)
+
+        pos_region_emb = self.poi2region(pos_poi_emb, data.poi_to_region, data.region_adjacency)
+        neg_region_emb = self.poi2region(neg_poi_emb, data.poi_to_region, data.region_adjacency)
+
+        city_emb = self.region2city(pos_region_emb, data.region_area)
+
+        self.checkin_embedding = pos_checkin_emb
+        self.poi_embedding = pos_poi_emb
+        self.region_embedding = pos_region_emb
+
+        pos_region_expanded = pos_region_emb[data.poi_to_region]
+        neg_region_indices = self._sample_negative_indices_with_similarity(
+            data.poi_to_region, num_regions, data.coarse_region_similarity, data.x.device
+        )
+        neg_region_expanded = pos_region_emb[neg_region_indices]
+
+        return (
+            pos_checkin_emb, pos_poi_emb,
+            pos_poi_emb, pos_region_expanded, neg_region_expanded,
+            pos_region_emb, neg_region_emb, city_emb,
+            data.checkin_to_poi, num_pois,
+        )
+
+    def loss(self, pos_checkin, pos_poi,
+             pos_poi_again, pos_region_exp, neg_region_exp,
+             pos_region, neg_region, city,
+             checkin_to_poi, num_pois):
+        # ---- Loss 1: InfoNCE for check-in -> POI ----
+        # anchor: project checkin embedding via W_c2p, then dot-product with pois
+        anchor = torch.matmul(pos_checkin, self.weight_c2p)         # [N_c, D]
+        anchor = F.normalize(anchor, dim=-1)
+        pois = F.normalize(pos_poi, dim=-1)                          # [N_p, D]
+
+        N_c = anchor.size(0)
+        K = self.num_negatives
+        device = anchor.device
+
+        pos_idx = checkin_to_poi                                     # [N_c]
+        # positive similarity
+        sim_pos = (anchor * pois[pos_idx]).sum(dim=-1, keepdim=True) # [N_c, 1]
+
+        # K random negatives (different from positive)
+        neg_idx = torch.randint(0, num_pois - 1, (N_c, K), device=device)
+        neg_idx = torch.where(neg_idx >= pos_idx.unsqueeze(-1), neg_idx + 1, neg_idx)
+
+        if self.chunk_size is None or N_c <= self.chunk_size:
+            # Gather negatives in one shot: [N_c, K, D]
+            neg_pois = pois[neg_idx]
+            sim_neg = (anchor.unsqueeze(1) * neg_pois).sum(dim=-1)
+        else:
+            # Chunked + gradient-checkpointed: materialize [chunk, K, D] only
+            # transiently and recompute it during backward instead of caching.
+            # On Florida-scale data (1.4 M check-ins, K=32, D=64) the full
+            # tensor is 11.5 GB; chunking alone saves only peak memory because
+            # autograd retains all chunks for backward. Checkpointing trades
+            # ~2× compute for ~chunk_size/N_c memory reduction.
+            from torch.utils.checkpoint import checkpoint as _checkpoint
+
+            def _sim_chunk(chunk_anchor, chunk_neg_idx, pois_ref):
+                chunk_neg_pois = pois_ref[chunk_neg_idx]
+                return (chunk_anchor.unsqueeze(1) * chunk_neg_pois).sum(dim=-1)
+
+            sim_neg_chunks = []
+            for i in range(0, N_c, self.chunk_size):
+                j = i + self.chunk_size
+                sim_neg_chunks.append(
+                    _checkpoint(
+                        _sim_chunk, anchor[i:j], neg_idx[i:j], pois,
+                        use_reentrant=False,
+                    )
+                )
+            sim_neg = torch.cat(sim_neg_chunks, dim=0)
+
+        logits = torch.cat([sim_pos, sim_neg], dim=1) / self.temperature  # [N_c, 1+K]
+        targets = torch.zeros(N_c, dtype=torch.long, device=device)        # positive at idx 0
+        loss_c2p = F.cross_entropy(logits, targets)
+
+        # ---- Loss 2: POI -> Region (bilinear-sigmoid-BCE, unchanged) ----
+        pos_p2r = self.discriminate(pos_poi, pos_region_exp, self.weight_p2r)
+        neg_p2r = self.discriminate(pos_poi, neg_region_exp, self.weight_p2r)
+        loss_p2r = -torch.log(pos_p2r + EPS).mean() - torch.log(1 - neg_p2r + EPS).mean()
+
+        # ---- Loss 3: Region -> City ----
+        pos_r2c = self.discriminate_global(pos_region, city, self.weight_r2c)
+        neg_r2c = self.discriminate_global(neg_region, city, self.weight_r2c)
+        loss_r2c = -torch.log(pos_r2c + EPS).mean() - torch.log(1 - neg_r2c + EPS).mean()
+
+        return (
+            self.alpha_c2p * loss_c2p
+            + self.alpha_p2r * loss_p2r
+            + self.alpha_r2c * loss_r2c
+        )
+
+
+# ---------------------------------------------------------------------------
+# V4: Uncertainty-weighted alphas (Kendall et al. 2018)
+# ---------------------------------------------------------------------------
+
+class Check2HGI_Uncertainty(Check2HGI):
+    """Replaces fixed alpha_{c2p, p2r, r2c} with learnable log-variance
+    parameters. Loss_i' = (1/(2σ_i^2)) * L_i + log σ_i.
+
+    log_var is clamped to [-3, 3] (Kendall stability trick) so the smallest
+    loss can't pull its log_var to -inf and collapse the head.
+    """
+
+    LOGVAR_MIN, LOGVAR_MAX = -3.0, 3.0
+
+    def __init__(self, *args, **kwargs):
+        # Drop alphas — they will be ignored.
+        super().__init__(*args, **kwargs)
+        self.log_var_c2p = nn.Parameter(torch.zeros(1))
+        self.log_var_p2r = nn.Parameter(torch.zeros(1))
+        self.log_var_r2c = nn.Parameter(torch.zeros(1))
+
+    def _clamp(self, lv):
+        return torch.clamp(lv, min=self.LOGVAR_MIN, max=self.LOGVAR_MAX)
+
+    def loss(self, pos_checkin, pos_poi_exp, neg_poi_exp,
+             pos_poi, pos_region_exp, neg_region_exp,
+             pos_region, neg_region, city):
+        pos_c2p = self.discriminate(pos_checkin, pos_poi_exp, self.weight_c2p)
+        neg_c2p = self.discriminate(pos_checkin, neg_poi_exp, self.weight_c2p)
+        loss_c2p = -torch.log(pos_c2p + EPS).mean() - torch.log(1 - neg_c2p + EPS).mean()
+
+        pos_p2r = self.discriminate(pos_poi, pos_region_exp, self.weight_p2r)
+        neg_p2r = self.discriminate(pos_poi, neg_region_exp, self.weight_p2r)
+        loss_p2r = -torch.log(pos_p2r + EPS).mean() - torch.log(1 - neg_p2r + EPS).mean()
+
+        pos_r2c = self.discriminate_global(pos_region, city, self.weight_r2c)
+        neg_r2c = self.discriminate_global(neg_region, city, self.weight_r2c)
+        loss_r2c = -torch.log(pos_r2c + EPS).mean() - torch.log(1 - neg_r2c + EPS).mean()
+
+        lv_c2p = self._clamp(self.log_var_c2p)
+        lv_p2r = self._clamp(self.log_var_p2r)
+        lv_r2c = self._clamp(self.log_var_r2c)
+        prec_c2p = torch.exp(-lv_c2p)
+        prec_p2r = torch.exp(-lv_p2r)
+        prec_r2c = torch.exp(-lv_r2c)
+
+        return (
+            0.5 * prec_c2p * loss_c2p + 0.5 * lv_c2p
+            + 0.5 * prec_p2r * loss_p2r + 0.5 * lv_p2r
+            + 0.5 * prec_r2c * loss_r2c + 0.5 * lv_r2c
+        ).squeeze()
+
+
+# ---------------------------------------------------------------------------
+# V5: Combined (InfoNCE + GAT-time + skip+LN encoder + uncertainty)
+# ---------------------------------------------------------------------------
+
+class Check2HGI_Combined(Check2HGI_InfoNCE):
+    """V1 + V4 combined — InfoNCE c2p with uncertainty-weighted multi-loss.
+    The encoder is passed in by the caller via checkin_encoder."""
+
+    LOGVAR_MIN, LOGVAR_MAX = -3.0, 3.0
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.log_var_c2p = nn.Parameter(torch.zeros(1))
+        self.log_var_p2r = nn.Parameter(torch.zeros(1))
+        self.log_var_r2c = nn.Parameter(torch.zeros(1))
+
+    def _clamp(self, lv):
+        return torch.clamp(lv, min=self.LOGVAR_MIN, max=self.LOGVAR_MAX)
+
+    def loss(self, pos_checkin, pos_poi,
+             pos_poi_again, pos_region_exp, neg_region_exp,
+             pos_region, neg_region, city,
+             checkin_to_poi, num_pois):
+        # InfoNCE c2p
+        anchor = torch.matmul(pos_checkin, self.weight_c2p)
+        anchor = F.normalize(anchor, dim=-1)
+        pois = F.normalize(pos_poi, dim=-1)
+        N_c = anchor.size(0); K = self.num_negatives; device = anchor.device
+        pos_idx = checkin_to_poi
+        sim_pos = (anchor * pois[pos_idx]).sum(dim=-1, keepdim=True)
+        neg_idx = torch.randint(0, num_pois - 1, (N_c, K), device=device)
+        neg_idx = torch.where(neg_idx >= pos_idx.unsqueeze(-1), neg_idx + 1, neg_idx)
+        sim_neg = (anchor.unsqueeze(1) * pois[neg_idx]).sum(dim=-1)
+        logits = torch.cat([sim_pos, sim_neg], dim=1) / self.temperature
+        targets = torch.zeros(N_c, dtype=torch.long, device=device)
+        loss_c2p = F.cross_entropy(logits, targets)
+
+        pos_p2r = self.discriminate(pos_poi, pos_region_exp, self.weight_p2r)
+        neg_p2r = self.discriminate(pos_poi, neg_region_exp, self.weight_p2r)
+        loss_p2r = -torch.log(pos_p2r + EPS).mean() - torch.log(1 - neg_p2r + EPS).mean()
+
+        pos_r2c = self.discriminate_global(pos_region, city, self.weight_r2c)
+        neg_r2c = self.discriminate_global(neg_region, city, self.weight_r2c)
+        loss_r2c = -torch.log(pos_r2c + EPS).mean() - torch.log(1 - neg_r2c + EPS).mean()
+
+        lv_c2p = self._clamp(self.log_var_c2p)
+        lv_p2r = self._clamp(self.log_var_p2r)
+        lv_r2c = self._clamp(self.log_var_r2c)
+        prec_c2p = torch.exp(-lv_c2p)
+        prec_p2r = torch.exp(-lv_p2r)
+        prec_r2c = torch.exp(-lv_r2c)
+
+        return (
+            0.5 * prec_c2p * loss_c2p + 0.5 * lv_c2p
+            + 0.5 * prec_p2r * loss_p2r + 0.5 * lv_p2r
+            + 0.5 * prec_r2c * loss_r2c + 0.5 * lv_r2c
+        ).squeeze()


### PR DESCRIPTION
Adds the Check2HGI variant family (UP1) and the trainer/harness used to sweep them on AL/AZ/FL.

Model + losses (research/embeddings/check2hgi/model/variants.py):
- GATTimeEncoder — 2-layer GATv2Conv with edge_dim=1 temporal-decay
- ResidualLNEncoder — 3-layer GCN + pre-LayerNorm + residual
- Check2HGI_InfoNCE — replaces C2P bilinear-BCE with K-negative InfoNCE; gat_infonce = GATTimeEncoder + InfoNCE (UP1 winner: AL STL next-cat F1 +14.94 pp over baseline check2hgi). chunk_size kwarg
  + gradient checkpointing for FL-scale (1.4M check-ins) memory.
- Check2HGI_Uncertainty — Kendall log-variance weighting (V4, null).
- Check2HGI_Combined — V5 (GCN + InfoNCE + uncertainty).

Trainer + harness (experiments/check2hgi_up/):
- run_variant.py — single-variant trainer + linear-probe eval; saves check-in/POI/region embedding parquets in p1_region_head_ablation schema. Supports --infonce_chunk_size and --amp {bf16,fp16,none}.
- run_all.py — orchestrates 9-variant × 3-seed sweep.
- run_stl_eval.py — bridge: swap output/check2hgi/{state}/embeddings.parquet to a variant, regenerate next.parquet, run scripts/train.py, restore.
- run_mtl_b3.py — MTL-B3 retest with a variant substrate.
- aggregate.py — cross-variant aggregation.
- eval_anchors.py — raw-features + majority-class probe floors.

.gitignore — exclude UP1 per-variant emb.parquet (~900 MB) since they are reproducible via run_all.py.

UP1 doc + results + UP2/UP3/UP4 study artifacts intentionally not included; they will land in their own commits.