### PR TITLE
closing_data: repoint live board-handoff nav links to HANDOFF.md (post-#38 cleanup)

### DIFF
--- a/docs/studies/PRE_FREEZE_PROGRAM.md
+++ b/docs/studies/PRE_FREEZE_PROGRAM.md
@@ -94,8 +94,8 @@ the leak surface). External baselines on the *second dataset* are out of scope u
 | Machine | Metering | Pre-freeze role | Notes |
 |---|---|---|---|
 | **A40** | unmetered workhorse | `mtl_frontier` R4–R9 (RUNNING) | Currently saturated by the conditional-coupling family (R4–R9). Pre-freeze GPU gates wait for it to free. |
-| **Mac M2 Pro** (user's local box) | local, MPS only | ✅ `second_dataset` Phase E + E2 DONE · ✅ **C1 confirm-on-G CLOSED (PR #26)** → now **board: build the light baseline embeddings** ([`closing_data/HANDOFF_BOARD.md`](closing_data/HANDOFF_BOARD.md)) | MPS fp32. Device rule: every paired comparison on ONE device-class — Macs build device-tolerant embeddings or own whole small states (AL/AZ), never split a comparison across MPS/CUDA. |
-| **M4 Pro** (user's 2nd Mac) | local, MPS only | ✅ `pre_freeze_gates` **A2 + A4 CLOSED (PR #27)** → board: light-cell overflow per [`closing_data/HANDOFF_BOARD.md`](closing_data/HANDOFF_BOARD.md) | optional second Mac for light baseline embeddings / small-state cells (same device rule). |
+| **Mac M2 Pro** (user's local box) | local, MPS only | ✅ `second_dataset` Phase E + E2 DONE · ✅ **C1 confirm-on-G CLOSED (PR #26)** → now **board: build the light baseline embeddings** ([`closing_data/HANDOFF.md`](closing_data/HANDOFF.md)) | MPS fp32. Device rule: every paired comparison on ONE device-class — Macs build device-tolerant embeddings or own whole small states (AL/AZ), never split a comparison across MPS/CUDA. |
+| **M4 Pro** (user's 2nd Mac) | local, MPS only | ✅ `pre_freeze_gates` **A2 + A4 CLOSED (PR #27)** → board: light-cell overflow per [`closing_data/HANDOFF.md`](closing_data/HANDOFF.md) | optional second Mac for light baseline embeddings / small-state cells (same device rule). |
 | **H100** | **6 h metered** | reserved for `closing_data` P3 (CA/TX v14 builds) | Do **not** spend on pre-freeze exploration. |
 
 ---

--- a/docs/studies/closing_data/FREEZE_READINESS.md
+++ b/docs/studies/closing_data/FREEZE_READINESS.md
@@ -3,8 +3,8 @@
 > Created 2026-06-17 from the PR #24/#26/#27 audit (24-agent workflow). This is the durable checklist of
 > everything standing between "now" and the P2 freeze. The **gate ledger** lives in
 > [`../PRE_FREEZE_PROGRAM.md`](../PRE_FREEZE_PROGRAM.md); this doc records the audit's cross-cutting findings
-> + the per-gate open work. The pre-freeze GPU/prep lanes are **DONE** (PR #28/#29); the board launch run-spec
-> for A40/A100/M2 Pro is [`HANDOFF_BOARD.md`](HANDOFF_BOARD.md).
+> + the per-gate open work. The pre-freeze GPU/prep lanes are **DONE** (PR #28/#29); the board phase is complete
+> and the current closing_data index (board done → baseline phase) is [`HANDOFF.md`](HANDOFF.md).
 
 ## 1 · Gate status (post-merge)
 


### PR DESCRIPTION
## What

Post-#38 cleanup. PR #38 (Macs board pt2) merged cleanly — all MACS board content (TX HMT 25.81/53.85, Istanbul stride-1 CTLE-SC + comparand + HMT, the HMT-GRN CPU-validation audit, the full 6-state HMT list in `RESULTS_BOARD §4`) is on main. Commit `02c160cb` consolidated the per-machine board handoffs into the 3 `BASELINE_*` files and **deleted** the stale `HANDOFF_BOARD*.md` run-specs.

This PR fixes the **two live navigation pointers** that still linked to the deleted `HANDOFF_BOARD.md`:

- `docs/studies/closing_data/FREEZE_READINESS.md` — the "board launch run-spec" pointer
- `docs/studies/PRE_FREEZE_PROGRAM.md` — the machine table's M2 Pro + M4 Pro board rows

Both now point to the current closing_data index `HANDOFF.md` (board done → baseline phase). **Link-only — no content or number changes.**

## Scope (deliberately minimal)

Per the chosen scope, this fixes only the **live navigation** links. Historical per-cell provenance refs that still mention `HANDOFF_BOARD{,_A100,_H100,_M2PRO}.md` (`CA_MTL_DIVERGENCE.md`, `BOARD_H100_STATUS.md`, `BOARD_H100_FINDINGS.md`, `AL_PRECISION_GATE.md`, `M2PRO_BUILD_LOG.md`, `log.md`) are **left as-is** — they record the lane a cell ran under (provenance), not actionable navigation.

## Verify

```
grep -c HANDOFF_BOARD docs/studies/closing_data/FREEZE_READINESS.md docs/studies/PRE_FREEZE_PROGRAM.md   # both 0
ls docs/studies/closing_data/HANDOFF.md   # target exists
```

## Note (out of scope, FYI)
The paper-facing `docs/baselines/{next_region/hmt_grn.md, next_category/ctle.md}` were not touched by #38 and still lack the TX + Istanbul rows; consolidating those is the separate step `RESULTS_BOARD §4` describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)