### PR TITLE
board(a40): TX cell CLOSED — fp32 MTL beats both ceilings (reg +2.06, cat +7.56)

### DIFF
--- a/docs/results/closing_data/a40/tx_ba2_fp32_s0.json
+++ b/docs/results/closing_data/a40/tx_ba2_fp32_s0.json
@@ -1,0 +1,48 @@
+{
+  "state": "texas",
+  "seed": 0,
+  "folds": 5,
+  "engine": "check2hgi_dk_ovl",
+  "precision": "TRUE fp32 (MTL_DISABLE_AMP=1)",
+  "windowing": "gated stride-1 overlap min_seq=10",
+  "nonfinite_skip_count": 0,
+  "stl_reg_ceiling_top10": 64.9597,
+  "mtl_reg_full_top10": 67.0243,
+  "mtl_reg_per_fold": [
+    66.9426,
+    67.326,
+    66.1358,
+    67.2301,
+    67.4869
+  ],
+  "mtl_reg_best_epochs": [
+    48,
+    49,
+    49,
+    50,
+    50
+  ],
+  "mtl_cat_macro_f1": 77.5115,
+  "mtl_cat_per_fold": [
+    77.7258,
+    77.3776,
+    77.4336,
+    77.5458,
+    77.4745
+  ],
+  "mtl_cat_best_epochs": [
+    50,
+    50,
+    50,
+    49,
+    50
+  ],
+  "delta_reg": 2.0646,
+  "delta_reg_margin": 2.0,
+  "verdict": "MTL BEATS the STL reg ceiling by +2.06pp (reg superiority) AND the cat ceiling by +7.56pp. The '>2pp' threshold-flag is SIGN-AGNOSTIC and does NOT apply here \u2014 +2.06 is a SURPLUS, not a deficit. The prior fp16 -2.41 / bf16 -2.37 were VOID Ampere-bf16 collapse artifacts (TX_A40_BF16_NAN.md).",
+  "prior_fp16_delta_reg": -2.4095,
+  "prior_bf16_delta_reg": -2.3705,
+  "note": "Definitive true-fp32 TX MTL, 0 non-finite skips. STL reg ceiling p1/fp32, reused. cat ceiling next_gru/fp32. Matched scorer FULL top10 fp32 both sides. reg best-epochs all late [48,49,49,50,50] (healthy), matching the H100 clean bf16 reg 67.13.",
+  "stl_cat_ceiling_macro_f1": 69.9492,
+  "delta_cat": 7.5623
+}

--- a/docs/studies/closing_data/RESULTS_BOARD.md
+++ b/docs/studies/closing_data/RESULTS_BOARD.md
@@ -7,8 +7,9 @@
 >
 > ⚠ **STATUS (2026-06-24).** CA + TX cells land via the open board PRs **#35 (H100)** / **#37 (A40)**; the
 > `mtl_cv` collate-correctness check + baseline validity are under audit (**workflow `wsftdemmg`**). Each cell
-> below carries a **provenance + status** marker. TX reg is **in-flight (fp32)**. Reconcile against the audit
-> verdict on merge.
+> below carries a **provenance + status** marker. TX reg is **settled** (fp32 5f, 0 skips: **67.02 → +2.06
+> beats**; the A40 bf16 −2.37 was a VOID Ampere-bf16 collapse, `TX_A40_BF16_NAN.md`). Reconcile against the
+> audit verdict on merge.
 
 ## 1 · Part-2 headline — MTL champion-G vs dedicated STL ceilings (Δ in pp)
 
@@ -21,12 +22,12 @@ static_weight cw=0.75, onecycle max-lr 3e-3, geom_simple selector; fp32-matched 
 | **AZ** | 1547 | 57.13 | **63.39** | **+6.26** ✅beats | 59.40 | 59.34 | **−0.06** ≈matches | fp32 | ✅ main |
 | **FL** | 4703 | 75.15 | **79.82** | **+4.68** ✅beats | 76.71 | 77.28 | **+0.57** ✅**beats** | fp32 | ✅ main |
 | **CA** | 8501 | 70.26 | **77.33** | **+7.07** ✅beats | 63.48 | 65.66 | **+2.18** ✅**beats** | bf16 | 🔶 PR #35 |
-| **TX** | 6553 | 69.95 | **75.87** | **+5.92** ✅beats | 64.96 | _in-flight_ | _(H100 clean: 67.13 → +2.17)_ | fp32 | ⏳ PR #37 |
+| **TX** | 6553 | 69.95 | **77.51** | **+7.56** ✅beats | 64.96 | **67.02** | **+2.06** ✅**beats** | fp32 | ⏳ A40 PR |
 | **Istanbul** | 520 (mahalle) | — | — | **+8.06** ✅beats | — | — | **−0.58** ≈matches | fp32 (4 seeds) | 🔶 PR #33-merged, GCN substrate |
 
 **Reading (the story, on real data):** MTL **beats the dedicated category ceiling at every state** (+4.7 … +7.7 pp)
 AND **beats-or-matches the region ceiling everywhere — including the largest states** (FL **+0.57**, CA **+2.18**;
-AL/AZ within ≈0.2; TX climbing above ceiling in fp32). The earlier fp16-autocast collapse (`CA_MTL_DIVERGENCE.md`)
+AL/AZ within ≈0.2; TX **+2.06**). The earlier fp16-autocast collapse (`CA_MTL_DIVERGENCE.md`)
 was **masking a genuine region win** — corrected precision flips the old "MTL sacrifices region" into Pareto-positive.
 
 > Per-fold arrays + best-epochs are in the source JSONs (§3). All cat best-epochs are late (ep16-50) and CA/TX
@@ -47,7 +48,7 @@ was **masking a genuine region win** — corrected precision flips the old "MTL 
 - `h100/{alabama,arizona,florida,california}_s0_stl_cat_ceiling.json` — STL cat ceilings (main)
 - `h100/california_s0_mtl/california_s0_mtl_final_score.json` — CA MTL final 5f (**PR #35** → main on merge)
 - `a40/tx_stl_cat_ceiling_s0.json` (69.95) · `a40/tx_stl_reg_ceiling_s0.json` (64.96) — TX ceilings (**PR #37/main**)
-- `a40/tx_*_mtl_*` + `h100/texas_s0_mtl/…` — TX MTL (bf16 VOID + fp32 in-flight; **PR #37/#35**)
+- `a40/tx_ba2_fp32_s0.json` — **TX MTL fp32 5f (CLEAN, 0 skips): reg 67.02 / +2.06, cat 77.51 / +7.56** (A40 PR). bf16 (`tx_ba2_bf16_s0.json`) is VOID (Ampere collapse)
 - STL **reg** ceilings: `docs/results/P1/region_head_*_dkovl*` (fp32, leak-free per-fold prior)
 
 **Narrative / per-cell docs:** `docs/studies/closing_data/`

--- a/docs/studies/closing_data/TX_A40_BF16_NAN.md
+++ b/docs/studies/closing_data/TX_A40_BF16_NAN.md
@@ -11,8 +11,9 @@ The A40's TX champion-G MTL **bf16** run NaN-collapsed (74,812 skipped optimizer
 substrate/engine/log_T, same torch**. The only uncontrolled axis is the **GPU device class**: an A40-**Ampere**
 bf16 *backward-pass* NaN gradient (finite loss — NOT the fp16 forward overflow that [[CA_MTL_DIVERGENCE]] fixed)
 that the H100-**Hopper** float trajectory does not cross under identical config. **The fix is true fp32**
-(`MTL_DISABLE_AMP=1`), which removes the bf16-rounding NaN; the live A40 fp32 run is clean and tracking **above
-the ceiling**.
+(`MTL_DISABLE_AMP=1`): the A40 fp32 run finished **CLEAN — 0 skips, reg 67.02 beats the 64.96 ceiling +2.06**,
+cat 77.51 (+7.56). **MTL beats BOTH heads**, matching the H100 (reg 67.13). The bf16 −2.37 / fp16 −2.41 are
+confirmed **VOID** Ampere-bf16 collapse artifacts. **CELL CLOSED.**
 
 ## Symptom (A40, `scripts/closing_data/a40_task2_tx_mtl_bf16.sh`)
 - champion-G MTL on `check2hgi_dk_ovl`, texas, seed 0, 5f, **bf16** (`MTL_AUTOCAST_BF16=1`), compiled+tf32.
@@ -53,26 +54,30 @@ H100 TX bf16 folds 1-2 (`[[TX_CELL]]`, autonomous per-fold): cat **77.69 / 77.31
 did not run a *better* path, it rode a *different, clean* per-device float trajectory.
 > ⚠ Caveat: the H100 TX is committed at only **2/5 folds** (no final 5-fold score yet).
 
-## The fix — true fp32 (`MTL_DISABLE_AMP=1`)
-`scripts/closing_data/a40_task2_tx_mtl_fp32.sh`. Full 23-bit mantissa removes the bf16-rounding NaN. **Live
-evidence (pid 1492926):** clean through **ep32, 0 skips**, reg **N65.78 and climbing** (above the 64.96 ceiling)
-— the OPPOSITE of the bf16 early-peak collapse, matching the H100's healthy trajectory. Board-consistent: fp32
-is the non-CA small/mid-state decision ([[AL_PRECISION_GATE]]); CA/FL/AL fp32 precedent closes/reverses the gap.
-- **Decisive check (watcher armed):** does fp32 cross ep33 (the bf16 onset) clean?
-  - **clears** → fp32 is the citable A40 TX cell (expected to beat the ceiling, matching the H100) — no code change.
-  - **also NaNs** → structural, not precision → contingency below.
-- **Contingency (only if fp32 also NaNs):** add a degenerate-softmax guard in `_STANAttention` (replace
-  `float('-inf')` with a large finite negative, e.g. `-1e4`, so a degenerate row softmaxes to finite-uniform),
-  and/or lower the reg-LR (3e-3 is the highest group, drives the dualtower STAN reg head). Both are **medium
-  risk** (change numerics / diverge from frozen champion-G) → require board-wide re-validation before any citable run.
+## The fix — true fp32 (`MTL_DISABLE_AMP=1`) — ✅ CONFIRMED
+`scripts/closing_data/a40_task2_tx_mtl_fp32.sh`. Full 23-bit mantissa removes the bf16-rounding NaN.
+**Final result (seed 0, 5f, 0 non-finite skips)** → `docs/results/closing_data/a40/tx_ba2_fp32_s0.json`:
 
-## TX cell status (seed 0, 5f, gated overlap)
+| metric | MTL (fp32) | per-fold | best-ep | ceiling | Δ |
+|---|---|---|---|---|---|
+| reg FULL top10 | **67.0243** | [66.94, 67.33, 66.14, 67.23, 67.49] | [48,49,49,50,50] | 64.9597 | **+2.06 (BEATS)** |
+| cat macro-F1 | **77.5115** | [77.73, 77.38, 77.43, 77.55, 77.47] | [50,50,50,49,50] | 69.9492 | **+7.56 (BEATS)** |
+
+**0 skips**, every fold a healthy **late** best-epoch — fp32 sailed clean through the ep33–50 zone where bf16
+NaN-collapsed. reg 67.02 ≈ the H100 clean bf16 (67.13), confirming the collapse was **Ampere-bf16-specific /
+precision-borne**. The contingency (degenerate-softmax guard / lower reg-LR) was **NOT needed**; no code change.
+Board-consistent: fp32 is the non-CA small/mid-state decision ([[AL_PRECISION_GATE]]).
+> ⚠ The driver's auto-verdict string *"FLAG re-scope (>2pp)"* is a **sign-agnostic** threshold check —
+> Δreg = **+2.06 is a SURPLUS (MTL beats)**, the opposite of a deficit; it does **NOT** trigger a reg-claim re-scope.
+
+## TX cell status (seed 0, 5f, gated overlap) — ✅ CLOSED
 | piece | value | source |
 |---|---|---|
-| STL reg ceiling (fp32, p1) | **64.96** | committed `e1aa4003` (clean, reused) |
-| STL cat ceiling (next_gru) | **69.95 ± 0.21** | committed `50d9611d` |
-| MTL cat macro-F1 (bf16) | **75.87** → **Δcat +5.92 (beats)** | bf16 run (cat unaffected by the reg NaN) |
-| MTL reg FULL top10 | **pending fp32** (bf16 −2.37 is VOID) | fp32 run in flight |
+| STL reg ceiling (fp32, p1) | **64.9597** | committed `e1aa4003` (clean, reused) |
+| STL cat ceiling (next_gru) | **69.9492 ± 0.21** | committed `50d9611d` |
+| MTL reg FULL top10 (fp32) | **67.0243** → **Δreg +2.06 (BEATS)** | fp32 run, 0 skips ✓ |
+| MTL cat macro-F1 (fp32) | **77.5115** → **Δcat +7.56 (BEATS)** | fp32 run ✓ |
+| **verdict** | **MTL beats BOTH ceilings (reg +2.06, cat +7.56)** — the −2.4 "reg re-scope" was the VOID Ampere-bf16 artifact | |
 
 ## Operational lessons (carry forward)
 1. **bf16 MTL is NOT cross-GPU portable at large-C scale.** A40-Ampere and H100-Hopper diverge under

--- a/scripts/closing_data/a40_task2_tx_mtl_fp32.sh
+++ b/scripts/closing_data/a40_task2_tx_mtl_fp32.sh
@@ -78,9 +78,11 @@ cj = sorted(glob.glob("docs/results/P1/region_head_texas_region_5f_50ep_tx_ovl_s
 h = next(iter(json.load(open(cj[-1]))["heads"].values()))
 stl = h["aggregate"]["top10_acc_mean"] * 100
 dreg = mtl_reg - stl
-verdict = ("INSIDE (|Δreg|<=1.5pp)" if abs(dreg) <= 1.5
+# sign-aware: a POSITIVE Δreg is MTL beating the ceiling (superiority), NOT a deficit to re-scope.
+verdict = (f"MTL BEATS reg ceiling +{dreg:.2f}pp (superiority)" if dreg >= 0
+           else "INSIDE (|Δreg|<=1.5pp)" if abs(dreg) <= 1.5
            else "borderline (<=2pp)" if abs(dreg) <= 2.0
-           else "FLAG reg-claim re-scope (>2pp) — NOT a stop")
+           else "FLAG reg-claim re-scope (Δreg<-2pp) — NOT a stop")
 out = {"state": "texas", "seed": 0, "folds": 5, "engine": "check2hgi_dk_ovl",
        "precision": "TRUE fp32 (MTL_DISABLE_AMP=1)", "windowing": "gated stride-1 overlap min_seq=10",
        "nonfinite_skip_count": skips, "stl_reg_ceiling_top10": round(stl, 4),


### PR DESCRIPTION
Closes the A40 lane's **TX** champion-G MTL cell (seed 0, 5f, gated overlap). Follow-up to the merged PR #37 (which carried the bf16 NaN diagnosis); this PR adds the **definitive true-fp32 result**.

## Result — MTL beats BOTH ceilings
| metric | MTL (fp32) | ceiling | Δ |
|---|---|---|---|
| reg FULL top10 | **67.0243** | 64.9597 | **+2.06 ✅ beats** |
| cat macro-F1 | **77.5115** | 69.9492 | **+7.56 ✅ beats** |

- **0 non-finite skips**; all reg best-epochs late [48,49,49,50,50] (healthy). reg 67.02 ≈ the H100's clean bf16 (67.13).
- Confirms the A40 **bf16 −2.37 / fp16 −2.41 were VOID** Ampere-bf16 backward-NaN collapse artifacts (`TX_A40_BF16_NAN.md`, 5-agent root-cause). The "−2.4 reg re-scope" flag is dead — TX is **Pareto-positive**.

## What's in this PR
- `docs/results/closing_data/a40/tx_ba2_fp32_s0.json` — final fp32 result (per-fold, best-epochs, sign-corrected verdict + Δcat).
- `docs/studies/closing_data/TX_A40_BF16_NAN.md` — settled to final (fix CONFIRMED, **cell CLOSED**).
- `docs/studies/closing_data/RESULTS_BOARD.md` — TX row settled: cat 77.51 / +7.56, reg 67.02 / +2.06 (was in-flight).
- `scripts/closing_data/a40_task2_tx_mtl_fp32.sh` — sign-aware verdict (a +Δreg surplus is superiority, not a re-scope flag).

## Board significance
With TX closed, **champion-G MTL beats the cat ceiling at every state (+4.7…+7.7) AND beats/matches the reg ceiling everywhere** (FL +0.57, CA +2.18, **TX +2.06**; AL/AZ ≈match). Operational lesson (documented): **bf16 MTL is not cross-GPU portable at large-C scale — use fp32 for large-state cells on Ampere.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)