### PR TITLE
baselines: fix conda/CUDA board blockers (fp16 NaN, .venv interp, CTLE sort)

### DIFF
--- a/docs/studies/closing_data/BASELINE_H100.md
+++ b/docs/studies/closing_data/BASELINE_H100.md
@@ -79,6 +79,43 @@ python scripts/baselines/b4_cascade.py --state florida --seed 0 --folds 5 --epoc
 4. **wide-head speed** — the `perf(mtl)` #33 fix is on main; without it FL reg is ~70× slower.
 5. **`build_next_region_for` is a Python loop over 1.27 M rows** — minutes, not a hang.
 
+## 4b · Code fixes needed to run these baselines on a conda/CUDA board
+
+Running the baselines on a **conda/CUDA** board (no `.venv`, fp16-unsafe single-task trainer) surfaced three
+code bugs (1–3, **fixed in this PR**) plus one operational gotcha (4). The fixes are env-gated /
+interpreter-agnostic / behaviour-preserving, so they're no-ops on the Mac/MPS board and on `main`'s existing
+behaviour. Any other CUDA/conda board (e.g. the A40) benefits automatically.
+
+1. **fp16 NaN collapse at FL scale (the important one).** `src/training/runners/_single_task_train.py`
+   (train loop) and `src/training/shared_evaluate.py` (eval) ran an **unconditional `torch.autocast(float16)`
+   on CUDA with no GradScaler and no off-switch** (MPS/CPU always got fp32 via `nullcontext` — why the Mac
+   AL/AZ cells were clean but the H100 FL cat head `loss=nan` ~ep12, freezing F1 at 0.69 ≪ the 75.15 ceiling).
+   The board protocol (§0) mandates **fp32** anyway. Patch: gate both autocast contexts on
+   `DISABLE_AMP` / `MTL_DISABLE_AMP` (same convention the MTL trainer already uses), then export
+   **`DISABLE_AMP=1 MTL_DISABLE_AMP=1`** for every CUDA baseline run. Validated NaN-free at FL.
+   Background: memory `mtl-fp16-autocast-no-gradscaler` (now updated to note the STL path bites too).
+2. **`.venv/bin/python` hardcoded for child subprocesses** — `scripts/closing_data/mac_baseline_compare.py`
+   (`PY` const, ~L45; also imported by `comparand_check2hgi_sc.py`) and `scripts/pre_freeze_gates/run_a2.py`
+   (`PY` const, ~L21). The conda board has no `.venv` → instant `FileNotFoundError`. Patch: `PY = os.environ.get("BASELINE_PY") or sys.executable`
+   (correct on every board — child uses the parent interpreter). Or just `export BASELINE_PY=$(which python)`.
+3. **CTLE-E2E window reconstruction used an unstable sort** — `scripts/baselines/ctle_e2e.py`
+   `_build_dk_ovl_windows` sorted check-ins with pandas' default `quicksort` (unstable), but the canonical
+   dk_ovl builder (`data/inputs/builders.py` `generate_next_input_from_checkins`) uses a **stable
+   `kind='mergesort'`**. On the rows sharing a `(userid, datetime)` (28 at FL) the tie reordered differently,
+   shifting 2/1.27 M window targets → the script's own `next_category` row-alignment assert fired and CTLE-E2E
+   crashed before training. Patch: `kind="mergesort"` on both sort sites (the assert is kept — the windowing
+   was made faithful, not weakened). Validated: all three alignment asserts pass at FL.
+4. **(operational, no code change) Step-1 (`build_overlap_probe_engine`) is non-idempotent** — it
+   unconditionally re-windows ~8 G of parquet. If `output/check2hgi_dk_ovl/<state>/input/{next,next_region}.parquet`
+   already exist with the expected rowcount (FL = 1,274,418), **skip it**; just (re)build the per-fold log_T
+   and run the comparand.
+
+> **Task (C) note (resolution, not a patch):** the "feature-concat control" the handoff says "needs a thin
+> builder" is **already implemented and more rigorous** — it's the closed A2 control via
+> `scripts/pre_freeze_gates/run_a2.py --states <st> --seeds 0 --tasks category region` (the `hgifeat` arm =
+> HGI ⊕ Check2HGI's exact per-visit node features: category one-hot + hour/dow sin/cos, alignment-asserted).
+> No new builder needed; HGI inputs must exist (`scripts/pre_freeze_gates/setup_hgi_inputs.py`).
+
 ## 5 · Outputs + honesty
 Commit per cell: `docs/results/closing_data/baseline_compare/florida_{ctle,check2hgi_sc}.json` (NOT gitignored);
 record CTLE-E2E + CSLSL numbers in `MACS_BOARD_RESULTS.md` + `RESULTS_BOARD.md §4`. **n=5 provisional**; CTLE

--- a/scripts/baselines/ctle_e2e.py
+++ b/scripts/baselines/ctle_e2e.py
@@ -163,11 +163,17 @@ def _build_dk_ovl_windows(state: str, expected_userids: np.ndarray,
     that windows row-align to the dk_ovl labels.
     """
     emb = IoPaths.load_embedd(state, ENGINE)[["userid", "placeid", "category", "datetime"]]
-    emb = emb.sort_values(["userid", "datetime"]).reset_index(drop=True)
+    # MUST match the canonical dk_ovl builder's STABLE sort
+    # (data.inputs.builders.generate_next_input_from_checkins, kind='mergesort').
+    # The default 'quicksort' is unstable, so on the 28 florida rows that share a
+    # (userid, datetime) it reorders the tie differently than the builder did,
+    # shifting 2 window targets and tripping the next_category alignment assert.
+    # mergesort is stable -> preserves the parquet row order under ties -> 0 diffs.
+    emb = emb.sort_values(["userid", "datetime"], kind="mergesort").reset_index(drop=True)
 
     poi_rows, hour_rows, uid_rows, cat_rows = [], [], [], []
     for uid, sub in emb.groupby("userid", sort=False):
-        sub = sub.sort_values("datetime").reset_index(drop=True)
+        sub = sub.sort_values("datetime", kind="mergesort").reset_index(drop=True)
         places = sub["placeid"].astype(np.int64).tolist()
         cats = sub["category"].tolist()
         hours = pd.to_datetime(sub["datetime"]).dt.hour.astype(np.int64).tolist()

--- a/scripts/closing_data/mac_baseline_compare.py
+++ b/scripts/closing_data/mac_baseline_compare.py
@@ -42,7 +42,10 @@ ENGINE = {  # baseline key -> EmbeddingEngine value + on-disk board dir
 REPO = _root
 OUT = REPO / "output"
 CANON = "output/check2hgi/{state}"  # graph maps + log_T source
-PY = str(REPO / ".venv/bin/python")
+# Child subprocesses must use the SAME interpreter as this parent. On the Mac board
+# that is .venv/bin/python; on the H100/A40 conda boards there is no .venv, so default
+# to sys.executable (universally correct). BASELINE_PY overrides if ever needed.
+PY = os.environ.get("BASELINE_PY") or sys.executable
 
 
 def log(m): print(f"[{time.strftime('%H:%M:%S')}] {m}", flush=True)

--- a/scripts/pre_freeze_gates/run_a2.py
+++ b/scripts/pre_freeze_gates/run_a2.py
@@ -18,7 +18,10 @@ import sys
 from pathlib import Path
 
 _root = Path(__file__).resolve().parents[2]
-PY = str(_root / ".venv" / "bin" / "python")
+# Use the SAME interpreter as this parent (.venv on the Mac board; conda on H100/A40 where
+# there is no .venv). BASELINE_PY overrides if ever needed.
+import os
+PY = os.environ.get("BASELINE_PY") or sys.executable
 HARNESS = str(_root / "scripts" / "p1_region_head_ablation.py")
 
 V14 = "check2hgi_design_k_resln_mae_l0_1"

--- a/scripts/run_baseline_chain_h100.sh
+++ b/scripts/run_baseline_chain_h100.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Overnight supervisor: after Task A (comparand, PID passed as $1) finishes, run the
+# remaining no-gate FL baselines serially (each needs the whole H100). E and B are
+# independent of A and of each other, so both run regardless of prior exit status.
+#   E = CSLSL cascade (b4_cascade, over v14 design_k substrate)
+#   B = CTLE-E2E (ctle_e2e)
+# Task C (feature-concat) and D (CTLE-SC, gated) are handled separately.
+cd /teamspace/studios/this_studio/PoiMtlNet
+export PYTHONPATH=src
+export MTL_CHUNK_VAL_METRIC=1 MTL_STRICT=1 MTL_COMPILE_DYNAMIC=1
+export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
+export TORCHINDUCTOR_CACHE_DIR=$HOME/.inductor_cache_board
+# fp32 (protocol §0) — avoid the no-GradScaler fp16 NaN collapse at FL scale.
+export DISABLE_AMP=1 MTL_DISABLE_AMP=1
+PY="$(which python)"
+
+A_PID="${1:-}"
+echo "=== [chain] START $(date -u) — waiting for Task A (PID ${A_PID}) ==="
+if [ -n "$A_PID" ]; then
+  while kill -0 "$A_PID" 2>/dev/null; do sleep 60; done
+fi
+echo "=== [chain] Task A finished; A output: ==="
+ls -la docs/results/closing_data/baseline_compare/florida_check2hgi_sc.json 2>/dev/null || echo "WARN: Task A json missing — continuing to E/B anyway"
+
+echo "=== [chain] Task E: CSLSL cascade @ FL $(date -u) ==="
+python scripts/baselines/b4_cascade.py --state florida --seed 0 --folds 5 --epochs 50 \
+    --python "$PY" > logs/taskE_cslsl_cascade_fl.log 2>&1 \
+  && echo "[chain] Task E OK $(date -u)" || echo "[chain] Task E FAILED $(date -u)"
+
+echo "=== [chain] Task B: CTLE-E2E @ FL $(date -u) ==="
+python scripts/baselines/ctle_e2e.py --state florida --seed 0 --folds 5 \
+    > logs/taskB_ctle_e2e_fl.log 2>&1 \
+  && echo "[chain] Task B OK $(date -u)" || echo "[chain] Task B FAILED $(date -u)"
+
+echo "=== [chain] Task C: A2 feature-concat control @ FL $(date -u) ==="
+# FL cell of the (AL/AZ-closed) A2 control: HGI⊕raw-visit-features vs HGI vs v14/v11.
+# seed 0 x 5 folds x 30ep (matches H100 protocol + closed AL/AZ analysis). 4 arms x 2 tasks.
+python scripts/pre_freeze_gates/run_a2.py --states florida --seeds 0 \
+    --tasks category region > logs/taskC_a2_concat_fl.log 2>&1 \
+  && echo "[chain] Task C OK $(date -u)" || echo "[chain] Task C FAILED $(date -u)"
+
+echo "=== [chain] COMPLETE $(date -u) ==="
+echo "--- outputs ---"
+ls -la results/ctle_e2e_b1/florida/ 2>/dev/null
+ls -la docs/results/closing_data/baseline_compare/florida_check2hgi_sc.json 2>/dev/null
+ls -la docs/results/P1/region_head_florida_*A2_*_s0.json 2>/dev/null

--- a/scripts/run_taskA_comparand_fl.sh
+++ b/scripts/run_taskA_comparand_fl.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Task A (BASELINE_H100 §2): Check2HGI-SC comparand @ FL (seed0 x 5f).
+# Step 1 (build_overlap_probe_engine) SKIPPED — already built (rowcount 1,274,418, Jun 22).
+# Step 2: per-fold log_T for dk_ovl engine (leak-free train-only prior).
+# Step 3: comparand training (cat + reg heads).
+set -euo pipefail
+cd /teamspace/studios/this_studio/PoiMtlNet
+export PYTHONPATH=src
+export MTL_CHUNK_VAL_METRIC=1 MTL_STRICT=1 MTL_COMPILE_DYNAMIC=1
+export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
+export TORCHINDUCTOR_CACHE_DIR=$HOME/.inductor_cache_board
+# fp32 (protocol §0) — the STL trainer/eval autocast fp16 has no GradScaler and NaN-collapses
+# at FL scale on CUDA. DISABLE_AMP forces fp32, matching the Mac (MPS) board numbers.
+export DISABLE_AMP=1 MTL_DISABLE_AMP=1
+
+echo "=== [Task A] START $(date -u) ==="
+
+echo "--- Step 2: per-fold log_T (florida / check2hgi_dk_ovl / seed0 / 5 folds) ---"
+python scripts/compute_region_transition.py --state florida \
+    --engine check2hgi_dk_ovl --per-fold --seed 0 --n-splits 5
+echo "--- Step 2 DONE $(date -u) ---"
+
+echo "--- Step 3: comparand_check2hgi_sc (florida, 5 folds, cat reg) ---"
+python scripts/closing_data/comparand_check2hgi_sc.py \
+    --state florida --folds 5 --heads cat reg
+echo "--- Step 3 DONE $(date -u) ---"
+
+echo "=== [Task A] COMPLETE $(date -u) ==="
+echo "--- output json ---"
+ls -la docs/results/closing_data/baseline_compare/florida_check2hgi_sc.json || echo "WARN: output json missing"

--- a/src/training/runners/_single_task_train.py
+++ b/src/training/runners/_single_task_train.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import logging
+import os
 import time
 from typing import Optional, List
 
@@ -62,9 +63,17 @@ def train_single_task(
 
     cb.on_train_begin(CallbackContext(epoch=0, epochs_total=epochs))
 
+    # fp16 autocast on CUDA has NO GradScaler here, so it NaN-collapses at large-state
+    # scale (e.g. FL/CA/TX). DISABLE_AMP=1 (or MTL_DISABLE_AMP=1) forces fp32 — which is
+    # also the board baseline protocol (BASELINE_*.md §0 mandates fp32) and matches the
+    # MPS/CPU path (always nullcontext). See memory: mtl-fp16-autocast-no-gradscaler.
+    _disable_amp = (
+        os.environ.get("DISABLE_AMP") == "1"
+        or os.environ.get("MTL_DISABLE_AMP") == "1"
+    )
     _autocast_ctx = (
         torch.autocast(device.type, dtype=torch.float16)
-        if device.type == 'cuda'
+        if device.type == 'cuda' and not _disable_amp
         else contextlib.nullcontext()
     )
 

--- a/src/training/shared_evaluate.py
+++ b/src/training/shared_evaluate.py
@@ -1,4 +1,5 @@
 import contextlib
+import os
 from typing import Union
 
 import numpy as np
@@ -16,9 +17,15 @@ def evaluate(model: nn.Module, loader: DataLoader, device: torch.device,
         model.load_state_dict(best_state)
     preds_list, truths_list = [], []
 
+    # Match the training-loop precision: DISABLE_AMP=1 / MTL_DISABLE_AMP=1 forces fp32
+    # eval (board baseline protocol + NaN-safety at large-state scale).
+    _disable_amp = (
+        os.environ.get("DISABLE_AMP") == "1"
+        or os.environ.get("MTL_DISABLE_AMP") == "1"
+    )
     _autocast_ctx = (
         torch.autocast(device.type, dtype=torch.float16)
-        if device.type == 'cuda'
+        if device.type == 'cuda' and not _disable_amp
         else contextlib.nullcontext()
     )
 


### PR DESCRIPTION
Fixes three code bugs that blocked the `closing_data` board baselines on a **conda/CUDA** host (H100). None appear on the Mac/MPS board, so they were latent. All fixes are **env-gated / interpreter-agnostic / behaviour-preserving** — no-ops on existing Mac + `main` behaviour, and any other CUDA/conda board (A40) benefits automatically.

## 1. fp16 NaN collapse at large-state scale (the important one)
`src/training/runners/_single_task_train.py` (train loop) and `src/training/shared_evaluate.py` (eval) ran an **unconditional `torch.autocast(float16)` on CUDA with no GradScaler and no off-switch**. MPS/CPU always used fp32 (`nullcontext`), so the Mac AL/AZ cells were clean — but the FL comparand cat head went `loss=nan` ~ep12, freezing macro-F1 **below** the 75.15 ceiling (the §3 sanity-gate catches it).

Fix: gate both autocast contexts on `DISABLE_AMP` / `MTL_DISABLE_AMP` (the convention the MTL trainer already uses). The board protocol (`BASELINE_*.md §0`) mandates fp32 anyway. Validated NaN-free at FL (F1 0.71 by ep3, climbing).

## 2. `.venv/bin/python` hardcoded for child subprocesses
`scripts/closing_data/mac_baseline_compare.py` and `scripts/pre_freeze_gates/run_a2.py` spawned child training with a hardcoded `.venv/bin/python` → instant `FileNotFoundError` on conda boards. Fix: `os.environ.get("BASELINE_PY") or sys.executable` (child uses the parent interpreter — correct on every board).

## 3. CTLE-E2E window reconstruction used an unstable sort
`scripts/baselines/ctle_e2e.py` `_build_dk_ovl_windows` sorted check-ins with pandas' default `quicksort` (unstable) while the canonical dk_ovl builder uses stable `kind='mergesort'`. On rows sharing a `(userid, datetime)` (28 at FL) the tie reordered, shifting 2/1.27M window targets and tripping the script's own `next_category` alignment assert (crash before training). Fix: `kind="mergesort"` on both sorts — the assert is **kept**; the windowing was made faithful, not weakened.

## Docs
`docs/studies/closing_data/BASELINE_H100.md` §4b documents all three fixes + the Step-1 (`build_overlap_probe_engine`) idempotency gotcha + the Task-C resolution (the "feature-concat control" is already implemented as the A2 `--add-visit-features` arm — no new builder needed). Adds the two helper runners used for the FL comparand + overnight baseline chain.

## Validation
- fp32 fix: FL cat head, no NaN, F1 climbing to ceiling.
- CTLE sort fix: all three alignment asserts pass at FL (CPU-validated, 0 category diffs under mergesort).
- The FL baseline cells (comparand / CTLE-E2E / CSLSL cascade) are running green on the H100 with these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)