### PR TITLE
board(a40): CSLSL cascade @ FL — ties parallel champion-G at scale (canonical dk_ovl, 5f)

### DIFF
--- a/docs/results/closing_data/a40/fl_cascade_s0.json
+++ b/docs/results/closing_data/a40/fl_cascade_s0.json
@@ -1,0 +1,39 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/florida/mtlnet_lr1.0e-04_bs2048_ep50_20260625_004640_1789847",
+  "seed": 0,
+  "tag": "fl_cascade_s0",
+  "method": "reg full=top10_acc_indist*(1-ood_frac) at indist-best epoch; cat=macro-f1 at f1-best epoch; per-task diagnostic-best, fold-mean",
+  "cat_macro_f1_mean": 79.8284,
+  "cat_macro_f1_std": 0.4883,
+  "cat_per_fold": [
+    79.4322,
+    79.9002,
+    79.8069,
+    79.3052,
+    80.6977
+  ],
+  "cat_best_epochs": [
+    48,
+    50,
+    47,
+    49,
+    48
+  ],
+  "reg_full_top10_mean": 77.2668,
+  "reg_full_top10_std": 0.9495,
+  "reg_per_fold": [
+    77.5694,
+    77.2579,
+    76.2296,
+    76.4009,
+    78.8762
+  ],
+  "reg_best_epochs": [
+    45,
+    45,
+    49,
+    45,
+    47
+  ],
+  "n_folds": 5
+}

--- a/docs/studies/closing_data/CSLSL_CASCADE.md
+++ b/docs/studies/closing_data/CSLSL_CASCADE.md
@@ -36,6 +36,14 @@ completion. FL canonical (`dk_ovl`, 5f, with comparand) **supersedes the M4 set-
 (`baseline_compare/florida_cslsl_cascade.json`: stride-9/min_seq=5, 4-fold MPS-OOM, no comparand →
 its own recommendation was "run FL CSLSL on CUDA/A40").
 
+**FL same-device champ-G comparand — IN-FLIGHT (fold 1/5 done, 2026-06-25).** Interim fold-1 cross-check
+(A40 champ-G FL, same v16 recipe + per-head optimizers, true fp32): cat **79.45** (ep48) / reg **77.71** (ep47).
+- vs cataloged **board champ-G FL** (H100, `FL_PRECISION_GATE.md` fp32 per-fold[0] 79.38/77.68): Δ **+0.07 / +0.03**
+  → reproduces the catalog to well within the cross-GPU ±0.3 pp tolerance (re-run is faithful).
+- vs **A40 cascade FL** fold1 (79.43/77.57): Δ **+0.02 / +0.15** → same-card tie holds at fold level (per-fold
+  wobble that averages toward the ±0.01 5-fold tie). Best-epochs late (47–48), matching board (47–49) + cascade (45–49).
+The full 5-fold same-device Δ + the §1b FL row's A40 champ-G cells fill on completion (~2.5 h remaining).
+
 **Reading:** cascade ≈ parallel champion-G — Δjoint ≤ 0.02 pp, far below fold-std (~1.3–3.3 pp). The cascade
 trades a hair of category (+0.20) for a hair of region (−0.17/−0.18), netting ~0. The cascade did **not** beat
 champion-G (the `b4_cascade.py` docstring's anti-overclaim sanity check passes). → Our parallel joint model is

--- a/docs/studies/closing_data/CSLSL_CASCADE.md
+++ b/docs/studies/closing_data/CSLSL_CASCADE.md
@@ -1,9 +1,11 @@
-# CSLSL cascade cell (role-3 baseline) — A40, 2026-06-24
+# CSLSL cascade cell (role-3 baseline) — A40, 2026-06-24/25
 
-> **Status: AL + AZ DONE (n=5 provisional, seed 0).** The CSLSL/CatDM **cascade** (directed cat→region,
+> **Status: AL + AZ + FL DONE (n=5 provisional, seed 0).** The CSLSL/CatDM **cascade** (directed cat→region,
 > symmetric cross-attention severed) is a **dead tie** with our parallel champion-G on the joint objective
-> at both small/mid states → our parallel bidirectional cross-attention matches the dominant published
-> multi-task alternative **at equal cost**. CA/TX deferred (deadline; "only if cheap" per `BASELINE_A40.md`).
+> at the small/mid (AL/AZ) AND the large (FL, 4703 regions) states → our parallel bidirectional cross-attention
+> matches the dominant published multi-task alternative **at equal cost**. (FL same-device champ-G comparand
+> in-flight as of 2026-06-25; FL cascade ties the §1 board champ-G FL to ±0.01.) CA/TX deferred (deadline;
+> "only if cheap" per `BASELINE_A40.md`).
 > Headline + board: [`RESULTS_BOARD.md §1b`](RESULTS_BOARD.md) and
 > [`../../results/closing_data/MACS_BOARD_RESULTS.md`](../../results/closing_data/MACS_BOARD_RESULTS.md).
 
@@ -22,9 +24,17 @@ geom_simple selector, checkin/region modality, log_T-KD off. Comparand = **champ
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
 | AL | 63.45 ±2.00 | 63.25 ±2.02 | +0.20 | 69.48 ±3.03 | 69.65 ±3.32 | −0.17 | 66.39 | 66.37 | **+0.02** |
 | AZ | 63.63 ±1.34 | 63.44 ±1.33 | +0.20 | 59.18 ±1.83 | 59.36 ±1.79 | −0.18 | 61.37 | 61.36 | **+0.00** |
+| FL | 79.83 ±0.49 | ⏳ A40 in-flight | — | 77.27 ±0.95 | ⏳ A40 in-flight | — | 78.54 | — | ⏳ |
 
 cat = macro-F1; reg = FULL top10_acc = `top10_acc_indist·(1−ood_fraction)` at the diagnostic-best epoch;
 joint = √(cat·reg); fold-mean ±pstd, matched scorer `scripts/closing_data/a40_score_matched.py`.
+
+**FL (large state, 4703 regions, 1.27M rows, dk_ovl/MIN_SEQ=10, true fp32, 0 skips):** cascade cat **79.83**
+/ reg **77.27** — vs the §1 board champ-G FL (H100, 79.82/77.28) → **Δcat +0.01 / Δreg −0.01**, essentially
+identical (cross-device). The A40 same-device champ-G FL is **in-flight** (~1.8h); its row + Δ fill on
+completion. FL canonical (`dk_ovl`, 5f, with comparand) **supersedes the M4 set-a partial**
+(`baseline_compare/florida_cslsl_cascade.json`: stride-9/min_seq=5, 4-fold MPS-OOM, no comparand →
+its own recommendation was "run FL CSLSL on CUDA/A40").
 
 **Reading:** cascade ≈ parallel champion-G — Δjoint ≤ 0.02 pp, far below fold-std (~1.3–3.3 pp). The cascade
 trades a hair of category (+0.20) for a hair of region (−0.17/−0.18), netting ~0. The cascade did **not** beat

--- a/docs/studies/closing_data/CSLSL_CASCADE.md
+++ b/docs/studies/closing_data/CSLSL_CASCADE.md
@@ -42,6 +42,41 @@ champion-G (the `b4_cascade.py` docstring's anti-overclaim sanity check passes).
 **at least as good as the cascade at equal cost**; the cross-task lift lives in the parallel coupling, and
 removing it for a directed cascade neither helps nor hurts at AL/AZ.
 
+## Verification — the mechanism is ACTIVE and EXERCISED (2026-06-25 audit)
+
+The near-identical metrics looked suspicious (could the cascade flags be silent no-ops, making the "cascade"
+secretly == champion-G?). Three independent code audits + the run artifacts say **NO — the cascade is a
+genuinely different, fully-exercised model.** The ±0.01–0.2 tie is a real result.
+
+**Code audits (3 agents, independent):**
+- `disable_cross_attn=True` → **ACTIVE**. `_coerce_cli_value` (`train.py:1224-1226`) maps `"True"`→ real bool;
+  `create_model` passes it to `MTLnetCrossAttn.__init__` (stored `model.py:264`); forward guards the cross-attn
+  loop with `if not self._disable_cross_attn:` (`mtlnet_crossattn_dualtower/model.py:64-70,149`). Runtime
+  instrumentation: the 2 cross-attn blocks were called **0×** with the flag set vs **2×** without. Disabling
+  cross-attn alone shifts init outputs (CAT max|Δ|=0.54, REG max|Δ|=0.086).
+- `cond_coupling=posterior … cond_detach=True` → **ACTIVE + trainable**. The reg head builds a **zero-init**
+  `cond_proj` (`next_stan_flow_dualtower/head.py:293-296`), injects the **live softmax cat-posterior** additively
+  into the pooled region feature (`model.py:114-127`, `head.py:477-482`), detached (feed-forward). `cond_proj` is
+  `requires_grad=True`, in the optimizer's reg group, and gets a nonzero gradient from step 1 (‖grad‖≈0.64) —
+  zero-init does NOT pin it. No freeze/zero-multiply applies.
+- Empirical instantiation: cascade has 2 extra trained tensors (`cond_proj.weight/bias`); same build path as
+  `train.py`; logits diverge at init purely from the cross-attn removal (coupling adds 0 at init by design).
+
+**Run-artifact proof (`cond_norm` = ‖cond_proj(cat_cond)‖, logged per epoch):**
+| run | cond_norm ep1 → ep50 | coupling present? |
+|---|---|---|
+| cascade AL fold1 | 0.078 → **1.574** (max 1.62) | yes — learned |
+| cascade FL fold1 | 0.291 → **4.613** (max 5.01) | yes — learned strongly (~16×) |
+| cascade FL fold3 | 0.275 → **4.407** | yes |
+| **champion-G (any fold)** | *column absent* | **no coupling** (cond_coupling=none) |
+
+So in the actual scored runs the directed cat→region coupling **grew from ~0 to a large magnitude** (FL ~4.6) —
+it is heavily used — and cross-attention was severed, yet the cascade still lands at champion-G's joint
+performance. **Conclusion:** the cascade genuinely explores a different coupling topology (severed symmetric
+channel + a strongly-learned directed edge) and **arrives at equivalent performance** → "cascade ≈ parallel"
+is a robust finding, not a plumbing artifact. The symmetric bidirectional cross-attention and the directed
+CSLSL-style cascade are **performance-equivalent on this substrate** (1.1k→4.7k regions).
+
 ## Provenance (reproduce)
 - **Substrate**: `check2hgi_dk_ovl` (= v14 design_k embeddings re-windowed gated stride-1, MIN_SEQ=10).
   Built/rebuilt on the A40 2026-06-24 via `build_overlap_probe_engine.py {alabama,arizona} 1 10`

--- a/docs/studies/closing_data/RESULTS_BOARD.md
+++ b/docs/studies/closing_data/RESULTS_BOARD.md
@@ -67,7 +67,9 @@ fold-mean ±pstd, matched scorer `a40_score_matched.py`. JSONs:
 (FL same-device champ-G `fl_champG_a40_s0.json` in-flight).)*
 **FL (large state, 4703 regions): cascade is again a tie.** vs the §1 board champ-G FL (H100, 79.82/77.28):
 **Δcat +0.01 / Δreg −0.01** — essentially identical (cross-device). The A40 same-device champ-G FL is
-**in-flight**; the row's A40 champ-G cells + Δ fill in on completion. FL canonical (`dk_ovl`, 5f, fp32) —
+**in-flight** (fold 1/5: cat 79.45 / reg 77.71 — reproduces the board champ-G FL fold-1 to ±0.07/±0.03 and
+ties the cascade fold-1 to +0.02/+0.15; on track); the row's A40 champ-G cells + Δ fill in on completion.
+FL canonical (`dk_ovl`, 5f, fp32) —
 **supersedes the M4 set-a partial** (`baseline_compare/florida_cslsl_cascade.json`, 4-fold MPS-OOM, no comparand).
 
 **Reading:** the cascade is a **dead tie** with our parallel champion-G on the joint objective

--- a/docs/studies/closing_data/RESULTS_BOARD.md
+++ b/docs/studies/closing_data/RESULTS_BOARD.md
@@ -59,10 +59,16 @@ gated stride-1 overlap (MIN_SEQ=10), **true fp32** (`MTL_DISABLE_AMP=1`, 0 non-f
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
 | **AL** | 63.45 ±2.00 | 63.25 ±2.02 | **+0.20** | 69.48 ±3.03 | 69.65 ±3.32 | **−0.17** | 66.39 | 66.37 | **+0.02** ≈tie |
 | **AZ** | 63.63 ±1.34 | 63.44 ±1.33 | **+0.20** | 59.18 ±1.83 | 59.36 ±1.79 | **−0.18** | 61.37 | 61.36 | **+0.00** ≈tie |
+| **FL** | 79.83 ±0.49 | ⏳ A40 | — | 77.27 ±0.95 | ⏳ A40 | — | 78.54 | — | ⏳ |
 
 *(cat = macro-F1; reg = FULL top10_acc = indist·(1−ood) at diagnostic-best epoch; joint = √(cat·reg);
 fold-mean ±pstd, matched scorer `a40_score_matched.py`. JSONs:
-`docs/results/closing_data/a40/{al,az}_{cascade,champG_a40}_s0.json`.)*
+`docs/results/closing_data/a40/{al,az,fl}_cascade_s0.json` + `{al,az}_champG_a40_s0.json`
+(FL same-device champ-G `fl_champG_a40_s0.json` in-flight).)*
+**FL (large state, 4703 regions): cascade is again a tie.** vs the §1 board champ-G FL (H100, 79.82/77.28):
+**Δcat +0.01 / Δreg −0.01** — essentially identical (cross-device). The A40 same-device champ-G FL is
+**in-flight**; the row's A40 champ-G cells + Δ fill in on completion. FL canonical (`dk_ovl`, 5f, fp32) —
+**supersedes the M4 set-a partial** (`baseline_compare/florida_cslsl_cascade.json`, 4-fold MPS-OOM, no comparand).
 
 **Reading:** the cascade is a **dead tie** with our parallel champion-G on the joint objective
 (Δjoint ≤ 0.02 pp ≪ fold-std). It trades a hair of category (+0.20) for a hair of region (−0.17/−0.18),


### PR DESCRIPTION
## A40 baseline lane — CSLSL cascade @ FL (continuation of merged #44)

Extends the role-3 **CSLSL/CatDM cascade** baseline (`b4_cascade.py`: directed cat→region edge, symmetric cross-attention disabled) to **Florida** — the large state (4703 regions, 1.27M rows). Same protocol as the merged AL/AZ cells (#44): `check2hgi_dk_ovl`, seed 0 × 5f, gated stride-1 overlap MIN_SEQ=10, **true fp32** (`MTL_DISABLE_AMP=1`, 0 non-finite skips, all 5 folds).

### Result — FL cascade
| metric | cascade FL | §1 board champ-G FL (H100) | Δ |
|---|---|---|---|
| cat macro-F1 | **79.83** ±0.49 | 79.82 | **+0.01** |
| reg FULL top10 | **77.27** ±0.95 | 77.28 | **−0.01** |
| joint √(cat·reg) | **78.54** | — | — |

**The cascade ties our parallel champion-G at the large state too** (±0.01 on both tasks) — consistent with the AL/AZ dead-tie (Δjoint ≤ 0.02). → Our parallel bidirectional cross-attention **matches the dominant published multi-task alternative at equal cost, across scale (1.1k → 4.7k regions).**

### Canonical, supersedes the M4 partial
This is the **canonical FL CSLSL** (`dk_ovl`, full 5-fold, with comparand). It supersedes the M4 set-a attempt (`baseline_compare/florida_cslsl_cascade.json`: stride-9/min_seq=5, 4-fold MPS-OOM, no comparand — which itself recommended running FL CSLSL on the A40).

### In-flight (this branch, follow-up commit)
- **Same-device champion-G FL** is running on the A40 now (~1.8h, true fp32). On completion I'll fill the §1b FL row's A40 champ-G cells + strict same-device Δ and push to this branch (PR updates).

### Prep
Rebuilt FL `dk_ovl` seed0 per-fold log_T (was stale vs the 06-20 `next_region`); MTL training code byte-identical to main (only STL `shared_evaluate`/`_single_task_train` changed in #43) → champ-G comparand stays clean.

### Files
- `docs/studies/closing_data/RESULTS_BOARD.md §1b` (FL row)
- `docs/studies/closing_data/CSLSL_CASCADE.md` (FL section)
- `docs/results/closing_data/a40/fl_cascade_s0.json`

CA/TX cascade deferred per handoff (deadline; "only if cheap").

🤖 Generated with [Claude Code](https://claude.com/claude-code)