### PR TITLE
board(a40): W6 category-side encoder-isolation probe — CLOSED (trunk, not transfer)

### DIFF
--- a/docs/results/closing_data/a40/al_w6_freezereg_s0.json
+++ b/docs/results/closing_data/a40/al_w6_freezereg_s0.json
@@ -1,0 +1,39 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/alabama/mtlnet_lr1.0e-04_bs2048_ep50_20260625_055557_1941575",
+  "seed": 0,
+  "tag": "al_w6_freezereg_s0",
+  "method": "reg full=top10_acc_indist*(1-ood_frac) at indist-best epoch; cat=macro-f1 at f1-best epoch; per-task diagnostic-best, fold-mean",
+  "cat_macro_f1_mean": 63.4954,
+  "cat_macro_f1_std": 1.7364,
+  "cat_per_fold": [
+    63.5868,
+    64.7305,
+    64.8248,
+    64.1981,
+    60.1367
+  ],
+  "cat_best_epochs": [
+    20,
+    17,
+    18,
+    14,
+    14
+  ],
+  "reg_full_top10_mean": 0.6478,
+  "reg_full_top10_std": 0.2289,
+  "reg_per_fold": [
+    0.436,
+    0.4205,
+    0.654,
+    0.6747,
+    1.0537
+  ],
+  "reg_best_epochs": [
+    6,
+    32,
+    10,
+    1,
+    11
+  ],
+  "n_folds": 5
+}

--- a/docs/results/closing_data/a40/az_w6_freezereg_s0.json
+++ b/docs/results/closing_data/a40/az_w6_freezereg_s0.json
@@ -1,0 +1,39 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/arizona/mtlnet_lr1.0e-04_bs2048_ep50_20260625_060527_1945958",
+  "seed": 0,
+  "tag": "az_w6_freezereg_s0",
+  "method": "reg full=top10_acc_indist*(1-ood_frac) at indist-best epoch; cat=macro-f1 at f1-best epoch; per-task diagnostic-best, fold-mean",
+  "cat_macro_f1_mean": 63.6693,
+  "cat_macro_f1_std": 1.2791,
+  "cat_per_fold": [
+    65.3849,
+    62.6669,
+    64.8811,
+    63.3813,
+    62.032
+  ],
+  "cat_best_epochs": [
+    23,
+    19,
+    22,
+    20,
+    21
+  ],
+  "reg_full_top10_mean": 0.4301,
+  "reg_full_top10_std": 0.1137,
+  "reg_per_fold": [
+    0.5426,
+    0.5177,
+    0.4878,
+    0.3634,
+    0.2389
+  ],
+  "reg_best_epochs": [
+    31,
+    1,
+    16,
+    10,
+    36
+  ],
+  "n_folds": 5
+}

--- a/docs/results/closing_data/a40/fl_champG_a40_4f_partial_s0.json
+++ b/docs/results/closing_data/a40/fl_champG_a40_4f_partial_s0.json
@@ -1,0 +1,35 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/florida/mtlnet_lr1.0e-04_bs2048_ep50_20260625_024827_1848230",
+  "seed": 0,
+  "tag": "fl_champG_a40_4f_partial_s0",
+  "method": "reg full=top10_acc_indist*(1-ood_frac) at indist-best epoch; cat=macro-f1 at f1-best epoch; per-task diagnostic-best, fold-mean",
+  "cat_macro_f1_mean": 79.5964,
+  "cat_macro_f1_std": 0.1846,
+  "cat_per_fold": [
+    79.4475,
+    79.8863,
+    79.6265,
+    79.4255
+  ],
+  "cat_best_epochs": [
+    48,
+    48,
+    47,
+    47
+  ],
+  "reg_full_top10_mean": 76.8254,
+  "reg_full_top10_std": 0.8363,
+  "reg_per_fold": [
+    77.7146,
+    77.4686,
+    75.6015,
+    76.5171
+  ],
+  "reg_best_epochs": [
+    47,
+    47,
+    49,
+    48
+  ],
+  "n_folds": 4
+}

--- a/docs/results/closing_data/a40/fl_w6_freezereg_s0.json
+++ b/docs/results/closing_data/a40/fl_w6_freezereg_s0.json
@@ -1,0 +1,39 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/florida/mtlnet_lr1.0e-04_bs2048_ep50_20260625_062409_1952096",
+  "seed": 0,
+  "tag": "fl_w6_freezereg_s0",
+  "method": "reg full=top10_acc_indist*(1-ood_frac) at indist-best epoch; cat=macro-f1 at f1-best epoch; per-task diagnostic-best, fold-mean",
+  "cat_macro_f1_mean": 79.7895,
+  "cat_macro_f1_std": 0.4613,
+  "cat_per_fold": [
+    79.4698,
+    79.8961,
+    79.6631,
+    79.2973,
+    80.6214
+  ],
+  "cat_best_epochs": [
+    47,
+    48,
+    50,
+    47,
+    50
+  ],
+  "reg_full_top10_mean": 0.1489,
+  "reg_full_top10_std": 0.0425,
+  "reg_per_fold": [
+    0.1189,
+    0.2013,
+    0.1958,
+    0.0942,
+    0.1346
+  ],
+  "reg_best_epochs": [
+    36,
+    33,
+    4,
+    13,
+    32
+  ],
+  "n_folds": 5
+}

--- a/docs/studies/closing_data/RESULTS_BOARD.md
+++ b/docs/studies/closing_data/RESULTS_BOARD.md
@@ -65,8 +65,9 @@ gated stride-1 overlap (MIN_SEQ=10), **true fp32** (`MTL_DISABLE_AMP=1`, 0 non-f
 fold-mean ±pstd, matched scorer `a40_score_matched.py`. JSONs:
 `docs/results/closing_data/a40/{al,az,fl}_cascade_s0.json` + `{al,az}_champG_a40_s0.json`.
 FL champ-G comparand = the §1 board (H100) value — the A40 same-device champ-G FL was **stopped at 4/5 folds**
-(re-tasked to W6) after its 4-fold mean reproduced the catalog to **±0.006 cat / ±0.16 reg**, so the FL tie
-rests on the board champ-G, cross-device ±0.01.)*
+(re-tasked to W6) after its 4-fold mean (cat 79.596 / reg 76.825, `a40/fl_champG_a40_4f_partial_s0.json`)
+reproduced the board 4-fold mean to **±0.006 cat / ±0.16 reg**, so the FL tie rests on the board champ-G,
+cross-device ±0.01.)*
 **FL (large state, 4703 regions): cascade is again a tie.** vs the §1 board champ-G FL (H100, 79.82/77.28):
 **Δcat +0.01 / Δreg −0.01** — essentially identical. FL canonical (`dk_ovl`, 5f, fp32) —
 **supersedes the M4 set-a partial** (`baseline_compare/florida_cslsl_cascade.json`, 4-fold MPS-OOM, no comparand).

--- a/docs/studies/closing_data/RESULTS_BOARD.md
+++ b/docs/studies/closing_data/RESULTS_BOARD.md
@@ -59,17 +59,16 @@ gated stride-1 overlap (MIN_SEQ=10), **true fp32** (`MTL_DISABLE_AMP=1`, 0 non-f
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
 | **AL** | 63.45 ±2.00 | 63.25 ±2.02 | **+0.20** | 69.48 ±3.03 | 69.65 ±3.32 | **−0.17** | 66.39 | 66.37 | **+0.02** ≈tie |
 | **AZ** | 63.63 ±1.34 | 63.44 ±1.33 | **+0.20** | 59.18 ±1.83 | 59.36 ±1.79 | **−0.18** | 61.37 | 61.36 | **+0.00** ≈tie |
-| **FL** | 79.83 ±0.49 | ⏳ A40 | — | 77.27 ±0.95 | ⏳ A40 | — | 78.54 | — | ⏳ |
+| **FL** | 79.83 ±0.49 | 79.82 (H100§1) | **+0.01** | 77.27 ±0.95 | 77.28 (H100§1) | **−0.01** | 78.54 | 78.55 | **−0.01** ≈tie |
 
 *(cat = macro-F1; reg = FULL top10_acc = indist·(1−ood) at diagnostic-best epoch; joint = √(cat·reg);
 fold-mean ±pstd, matched scorer `a40_score_matched.py`. JSONs:
-`docs/results/closing_data/a40/{al,az,fl}_cascade_s0.json` + `{al,az}_champG_a40_s0.json`
-(FL same-device champ-G `fl_champG_a40_s0.json` in-flight).)*
+`docs/results/closing_data/a40/{al,az,fl}_cascade_s0.json` + `{al,az}_champG_a40_s0.json`.
+FL champ-G comparand = the §1 board (H100) value — the A40 same-device champ-G FL was **stopped at 4/5 folds**
+(re-tasked to W6) after its 4-fold mean reproduced the catalog to **±0.006 cat / ±0.16 reg**, so the FL tie
+rests on the board champ-G, cross-device ±0.01.)*
 **FL (large state, 4703 regions): cascade is again a tie.** vs the §1 board champ-G FL (H100, 79.82/77.28):
-**Δcat +0.01 / Δreg −0.01** — essentially identical (cross-device). The A40 same-device champ-G FL is
-**in-flight** (fold 1/5: cat 79.45 / reg 77.71 — reproduces the board champ-G FL fold-1 to ±0.07/±0.03 and
-ties the cascade fold-1 to +0.02/+0.15; on track); the row's A40 champ-G cells + Δ fill in on completion.
-FL canonical (`dk_ovl`, 5f, fp32) —
+**Δcat +0.01 / Δreg −0.01** — essentially identical. FL canonical (`dk_ovl`, 5f, fp32) —
 **supersedes the M4 set-a partial** (`baseline_compare/florida_cslsl_cascade.json`, 4-fold MPS-OOM, no comparand).
 
 **Reading:** the cascade is a **dead tie** with our parallel champion-G on the joint objective
@@ -80,6 +79,26 @@ channel helps or hurts materially at AL/AZ. **n=5 provisional** (seed 0; {1,7,10
 Cascade did NOT beat champion-G (the `b4_cascade.py` wiring sanity check passes). **Cross-device check:**
 the A40 champion-G re-run reproduces the board (H100) champion-G — AZ cat/reg within ±0.05 pp,
 AL cat −0.31 / reg −0.16 (≤ fold-std). CA/TX cascade deferred (deadline; CA/TX only "if cheap" per handoff).
+
+## 1c · W6 — category-side encoder-isolation probe (mechanism: trunk, not transfer)
+
+Freeze the **region** stream at init (`--freeze-reg-stream`) + reg loss off (`--category-weight 1.0`), train
+champion-G on `check2hgi_dk_ovl`, read the **category** head (seed 0 × 5f, true fp32, A40). Tests the §6.2
+claim directly (the cat win is "a stronger shared encoder, NOT region→category transfer") — the right direction
+vs F49 (which freezes the cat stream).
+
+| State | STL cat ceiling | full-MTL cat (§1) | **probe cat (region frozen)** | Δ vs ceiling | Δ vs full-MTL |
+|---|---:|---:|---:|---:|---:|
+| AL | 55.87 | 63.56 | **63.50 ±1.74** | **+7.63** | −0.06 |
+| AZ | 57.13 | 63.39 | **63.67 ±1.28** | **+6.54** | +0.28 |
+| FL | 75.15 | 79.82 | **79.79 ±0.46** | **+4.64** | −0.03 |
+
+**Verdict: W6 CLOSED.** With the region stream frozen-at-init (no learned region signal, cannot co-adapt via
+cross-attn K/V), the category head keeps the **entire** joint lift — probe cat ≈ full-MTL cat (±0.3 pp) and
+**≫ STL ceiling (+4.6…+7.6 pp)** at all three states. → the category benefit is the **shared trunk
+(architecture/capacity), NOT cross-task transfer**. Freeze verified (reg optimizer group = 0 trainable params,
+all states; 0 nan). **n=5 provisional.** Full cell: `W6_ENCODER_ISOLATION.md`; JSONs
+`a40/{al,az,fl}_w6_freezereg_s0.json`.
 
 ## 2 · Precision verdict (settled) & schedule ablation (NULL)
 - **bf16 ≈ fp32** on quality (Δ≤0.12 pp) and ~0 wall-clock (overlap is data-bound, GPU util 8-25%) →

--- a/docs/studies/closing_data/W6_ENCODER_ISOLATION.md
+++ b/docs/studies/closing_data/W6_ENCODER_ISOLATION.md
@@ -1,0 +1,61 @@
+# W6 — category-side encoder-isolation probe (A40, 2026-06-25) — **CLOSED**
+
+> **Verdict: W6 CLOSED. The joint CATEGORY win is the shared TRUNK (architecture/capacity), NOT
+> region→category transfer.** With the region stream frozen-at-init (no learned region signal, cannot
+> co-adapt as a cat-helper via cross-attention K/V) and the reg loss off, the category head keeps the **entire**
+> joint lift: probe cat ≈ full-MTL cat (±0.3 pp) and **≫ the STL cat ceiling (+4.6 … +7.6 pp)** at all three
+> states. This is the direct, correct-direction evidence for the paper's §6.2 mechanism sentence (the only
+> prior probe, F49, freezes the *cat* stream → measures the region pathway, the opposite direction).
+
+## 1 · The test
+Freeze the **region** stream (`next_encoder` + `next_poi`, `requires_grad=False` → stuck at init) via
+`--freeze-reg-stream`, and zero the reg loss (`--category-weight 1.0`). Train champion-G, read the **category**
+head. Comparand = the **STL cat ceiling** (dedicated single-task category, on disk) and **full-MTL cat**
+(RESULTS_BOARD §1). Mechanism: a frozen-at-init region stream provides no learned region signal and cannot
+co-adapt through the cross-attention K/V, so any cat lift over the STL ceiling must come from the shared trunk.
+- probe cat ≈ full-MTL cat ≫ STL ceiling  → **shared trunk** (architecture), not transfer → **W6 closed**.
+- probe cat ≈ STL ceiling                 → the cat win **was** region→category transfer → rewrite §6.2.
+
+## 2 · Result (seed 0 × 5f, A40, true fp32, region stream frozen)
+| State | STL cat ceiling | full-MTL cat (§1) | **probe cat (freeze-reg)** | Δ vs ceiling | Δ vs full-MTL | verdict |
+|---|---:|---:|---:|---:|---:|---|
+| AL | 55.87 | 63.56 | **63.50 ±1.74** | **+7.63** | −0.06 | **trunk** ✅ |
+| AZ | 57.13 | 63.39 | **63.67 ±1.28** | **+6.54** | +0.28 | **trunk** ✅ |
+| FL | 75.15 | 79.82 | **79.79 ±0.46** | **+4.64** | −0.03 | **trunk** ✅ |
+
+cat = macro-F1 at the f1-best epoch, fold-mean ±pstd (matched scorer `a40_score_matched.py`). Per-fold probe cat:
+AL [63.59,64.73,64.82,64.20,60.14] · AZ [65.38,62.67,64.88,63.38,62.03] · FL [79.47,79.90,79.66,79.30,80.62].
+Best-epochs late (FL 47–50; AL/AZ 14–23) — normal champion-G cat trajectory, no NaN/early-collapse.
+
+**Reading:** at every state the probe cat is statistically indistinguishable from full-MTL cat (Δ ≤ 0.3 pp ≪
+fold-std) and clears the STL cat ceiling by **+4.6 … +7.6 pp**. The category lift survives **in full** with the
+region stream frozen → it is the stronger **shared encoder on its own** (a trunk/capacity effect), not
+region→category transfer. The paper's §6.2 mechanism sentence stands as written; cite this (category-side,
+direct) probe in place of / alongside the F49 (region-side) citation.
+
+## 3 · Sanity gates (all passed)
+- **Freeze took** — every state's first-fold `[per-head-LR] optimizer groups` shows the **reg group at 0
+  trainable params** (`('reg', …, 0)`); cat 1,731,079 + shared 1,584,128 train. 0 freeze RuntimeErrors.
+- **Cat head trains normally** — late best-epochs, **0 non-finite skips** (true fp32 via `DISABLE_AMP=1`),
+  no ep12 collapse.
+- reg metric ignored (reg frozen + loss off → meaningless), per design.
+
+## 4 · Provenance (reproduce)
+- Runner `scripts/run_freeze_reg_probe.sh` (champion-G v16 on `check2hgi_dk_ovl` + `--category-weight 1.0
+  --freeze-reg-stream`, seed 0 × 5f, `--compile --tf32`, true fp32 `DISABLE_AMP=1 MTL_DISABLE_AMP=1`).
+  **Runner fix this session** (commit in this PR): added `--canon none` + 3 omitted v16 flags
+  (`--checkpoint-selector geom_simple --no-{reg,cat}-class-weights`) + dk_ovl log_T dir — without `--canon
+  none` the runner's own `MTL_STRICT=1` hard-failed the v16-vs-dk_ovl wrong-substrate guard before training.
+- Substrate: `check2hgi_dk_ovl` (v14 design_k re-windowed gated stride-1, MIN_SEQ=10); AL/AZ rebuilt + FL log_T
+  refreshed this session (the log_T is **unused** here — reg loss off + α frozen — but the preflight wants it
+  fresh). Flag + runner shipped in `ae898042`.
+- JSONs: `docs/results/closing_data/a40/{al,az,fl}_w6_freezereg_s0.json`. STL cat ceilings:
+  `docs/results/closing_data/h100/<state>_s0_stl_cat_ceiling.json` (7-class, device-robust → A40 fine).
+- **n=5 provisional** (seed 0; {1,7,100}→n=20 post-deadline).
+
+## 5 · For the paper (do NOT spin)
+Expected result obtained: the cat win is architecture, not transfer. Use as the encoder-isolation evidence in
+§6.2 (R3 structural-bottleneck / REVIEW_PANEL W6). Honest framing: "with the region stream frozen at
+initialization, the shared encoder alone recovers the full multi-task category gain (+4.6…+7.6 pp over the
+dedicated single-task ceiling) — the category benefit is a stronger shared representation, not cross-task
+(region→category) transfer."

--- a/docs/studies/closing_data/log.md
+++ b/docs/studies/closing_data/log.md
@@ -222,3 +222,33 @@ v16-pins-v14 substrate guard hard-fails under STRICT on dk_ovl; WARN-only withou
 **Outputs**: `RESULTS_BOARD.md §1b`, `../../results/closing_data/MACS_BOARD_RESULTS.md`, cell
 `CSLSL_CASCADE.md`; JSONs `../../results/closing_data/a40/{al,az}_{cascade,champG_a40}_s0.json`.
 **Deferred** (deadline; "only if cheap" per handoff): CA/TX cascade.
+
+---
+
+## 2026-06-25 — A40: CSLSL @ FL (tie at scale) + W6 encoder-isolation probe (CLOSED)
+
+**FL CSLSL cascade** (canonical `dk_ovl`, 5f, true fp32): cat **79.83** / reg **77.27** — ties the §1 board
+champ-G FL (H100, 79.82/77.28) to **±0.01** (cross-device). The A40 same-device champ-G FL comparand was
+**STOPPED at 4/5 folds** (re-tasked to W6) after its 4-fold mean (cat 79.596 / reg 76.825,
+`fl_champG_a40_4f_partial_s0.json`) reproduced the board 4-fold mean to **±0.006 cat / ±0.16 reg**. Supersedes
+the M4 set-a partial (MPS-OOM, no comparand). **Audit** (3 agents + run artifacts): the cascade flags are
+genuinely ACTIVE — `disable_cross_attn` bypasses the 2-block cross-attn stack (runtime 0 vs 2 calls); the
+directed coupling LEARNED (`cond_norm` AL 0.08→1.6, FL 0.29→4.6; absent in champ-G) → the ±0.01 tie is a real
+"cascade ≈ parallel" result, not a no-op. PRs #44 (AL/AZ) + #46 (FL) MERGED.
+
+**W6 category-side encoder-isolation probe — CLOSED.** Freeze the region stream at init
+(`--freeze-reg-stream`) + reg loss off (`--category-weight 1.0`), read the cat head (seed 0 × 5f, true fp32).
+Probe cat vs STL ceiling / full-MTL cat: AL 63.50 (+7.63 / −0.06), AZ 63.67 (+6.54 / +0.28),
+FL 79.79 (+4.64 / −0.03). → with the region stream frozen, the cat head keeps the ENTIRE joint lift → the
+category win is the **shared TRUNK (architecture), NOT region→category transfer**. Freeze verified (reg
+optimizer group = 0 trainable params, all 3 states). Direct, correct-direction evidence for §6.2 (F49 is
+region-side). Fixed a real bug in the shipped runner (`run_freeze_reg_probe.sh` lacked `--canon none` → its own
+`MTL_STRICT=1` hard-failed the v16-vs-dk_ovl substrate guard before training).
+
+**Recurring trap (cost time twice):** champion-G on `check2hgi_dk_ovl` under `MTL_STRICT=1` MUST pass
+`--canon none` + the full explicit recipe (auto-canon v16 pins the v14 substrate → wrong-substrate guard
+hard-fails). All board dk_ovl drivers do this; the W6 runner forgot it.
+
+**Outputs**: `W6_ENCODER_ISOLATION.md`, `RESULTS_BOARD.md §1c` (W6) + §1b FL row resolved; JSONs
+`a40/{al,az,fl}_w6_freezereg_s0.json` + `a40/fl_champG_a40_4f_partial_s0.json`. **PR #48** (W6, open).
+**Deferred** (post-deadline): {1,7,100}→n=20; CA/TX cascade.

--- a/scripts/run_freeze_reg_probe.sh
+++ b/scripts/run_freeze_reg_probe.sh
@@ -52,7 +52,9 @@ run_one() {
       --task-a-input-type checkin --task-b-input-type region --log-t-kd-weight 0.0 \
       --scheduler onecycle --max-lr 3e-3 --cat-lr 1e-3 --reg-lr 3e-3 --shared-lr 1e-3 \
       --model mtlnet_crossattn_dualtower --compile --tf32 \
-      --per-fold-transition-dir "output/check2hgi_design_k_resln_mae_l0_1/${state}" --no-checkpoints
+      --checkpoint-selector geom_simple --no-reg-class-weights --no-cat-class-weights \
+      --canon none \
+      --per-fold-transition-dir "output/check2hgi_dk_ovl/${state}" --no-checkpoints
   # Score cat macro-F1 (the only head that matters here) and compare to the STL cat ceiling.
   echo "  -> score cat macro-F1 from the rundir; compare to ${state}_s0_stl_cat_ceiling.json"
 }


### PR DESCRIPTION
## A40 · W6 category-side encoder-isolation probe (`HANDOFF_A40_W6_PROBE.md`)

Closes the last open regular-track mechanism blocker (REVIEW_PANEL **W6** / R3 structural-bottleneck). Tests the paper's §6.2 claim **directly and in the correct direction**: the joint **category** win is *"a stronger shared encoder, NOT region→category transfer."* (The only prior probe, F49, freezes the *cat* stream → measures the region pathway, the opposite direction — a reviewer catches the mismatch.)

**Method:** freeze the **region** stream at init (`--freeze-reg-stream` → `next_encoder`+`next_poi` `requires_grad=False`, can't co-adapt as a cat-helper via cross-attn K/V) + reg loss off (`--category-weight 1.0`); train champion-G on `check2hgi_dk_ovl`, read the category head. Seed 0 × 5f, true fp32, A40.

### Result — W6 CLOSED ✅
| State | STL cat ceiling | full-MTL cat (§1) | **probe cat (region frozen)** | Δ vs ceiling | Δ vs full-MTL |
|---|---:|---:|---:|---:|---:|
| AL | 55.87 | 63.56 | **63.50 ±1.74** | **+7.63** | −0.06 |
| AZ | 57.13 | 63.39 | **63.67 ±1.28** | **+6.54** | +0.28 |
| FL | 75.15 | 79.82 | **79.79 ±0.46** | **+4.64** | −0.03 |

With the region stream frozen-at-init, the category head keeps the **entire** joint lift — probe cat ≈ full-MTL cat (±0.3 pp) and **≫ STL ceiling (+4.6…+7.6 pp)** at all three states. → **the category benefit is the shared TRUNK (architecture/capacity), not cross-task transfer.** The §6.2 mechanism sentence stands; cite this (category-side, direct) probe in place of / alongside F49.

**Sanity gates passed:** freeze verified at every state (reg optimizer group = **0 trainable params**; cat 1.73M + shared 1.58M train), 0 freeze errors, 0 nan, true fp32 (`DISABLE_AMP=1`), late best-epochs.

### Runner bug fixed (commit `719d78aa`)
The shipped `run_freeze_reg_probe.sh` set `MTL_STRICT=1` but relied on auto-canon v16 (v14-pinned) while training on `dk_ovl` → the wrong-substrate guard **hard-failed before training** (reproduced). Fixed to match the board dk_ovl drivers: `--canon none` + the full explicit champion-G recipe (added the 3 omitted v16 flags: `--checkpoint-selector geom_simple --no-{reg,cat}-class-weights`) + dk_ovl log_T dir (fresh, engine-matched; log_T is unused here so result-neutral).

### Also: resolves the stale §1b FL champ-G ⏳
The A40 same-device champ-G FL comparand was **stopped at 4/5 folds** (re-tasked to W6 per `f0340569`) after its 4-fold mean reproduced the catalog to **±0.006 cat / ±0.16 reg** → the FL CSLSL tie now rests on the board (H100) champ-G, cross-device ±0.01.

### Files
- `docs/studies/closing_data/W6_ENCODER_ISOLATION.md` (cell doc + verdict)
- `docs/studies/closing_data/RESULTS_BOARD.md` §1c (W6) + §1b FL row resolved
- `docs/results/closing_data/a40/{al,az,fl}_w6_freezereg_s0.json`
- `scripts/run_freeze_reg_probe.sh` (runner fix)

**n=5 provisional** (seed 0; {1,7,100}→n=20 post-deadline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)