### PR TITLE
closing_data_v2: J1 joint-best (deployable checkpoint) re-score of the v17 board

### DIFF
--- a/articles/[mobiwac]/J1_JOINT_SCORE_RUNBOOK.md
+++ b/articles/[mobiwac]/J1_JOINT_SCORE_RUNBOOK.md
@@ -1,5 +1,14 @@
 # J1 — Joint-checkpoint scoring runbook (A40)
 
+> ✅ **EXECUTED 2026-07-09 → [`../../docs/studies/closing_data_v2/`](../../docs/studies/closing_data_v2/).**
+> All 18 v17/`dk_ovl` MTL rundirs scored (CPU-only). **Finding: the served single checkpoint reproduces
+> Table 3 within ≤ 0.06 pp cat / ≤ 0.11 pp reg on every dataset (largest 0.051 / 0.107, both at AZ) — no verdict changes.** Category still beats
+> everywhere; region still beats at Istanbul/FL/TX/CA (Istanbul margin +0.28→+0.19, still positive, 20/20 folds)
+> and matches at AL/AZ (the AL tail risk did not materialize: −0.31→−0.41, far from the −2 pp bound). Three
+> self-audits (diag-parity 18/18, joint-epoch 90/90, paper-parity 6/6) + a 4-agent independent audit all pass.
+> The corrected side-by-side table + decision memo: [`../../docs/studies/closing_data_v2/JOINT_BEST_RESULTS.md`](../../docs/studies/closing_data_v2/JOINT_BEST_RESULTS.md).
+> CA/TX stay seed-0 provisional (n=20 blocked on the A1 GPU top-up, not on J1).
+
 > **Why this doc exists.** The paper's Table 3 MTL cells are **per-task diagnostic-best** (category at
 > its F1-best epoch, region at its own Acc@10-best epoch — two different checkpoints per fold; proof:
 > AL s0 cat epochs [17,17,16,17,17] vs reg [27,25,28,22,37]). Training also saves a **single joint
@@ -39,11 +48,14 @@ PYTHONPATH=src .venv/bin/python scripts/closing_data/score_joint_best.py <rundir
 3. The selector uses reg **Acc@10-indist** (as training did); reported reg = `indist × (1 − ood_frac)`
    at that epoch — same full-catalog convention as the paper.
 
-## Where the results go
+## Where the results go  (✅ done — see the EXECUTED banner above)
 
-- Sidecars: committed into the rundirs' result trees (same C28 flow as `*_matched_score.json`).
-- Aggregate + decision memo: append to
-  [`../../docs/studies/closing_data/JOINT_BEST_SCORING.md`](../../docs/studies/closing_data/JOINT_BEST_SCORING.md) §Results.
+- Sidecars: `joint_best_score.json` written into all 18 rundirs' result trees. **Note:** those live under
+  `results/check2hgi_dk_ovl/` which is **gitignored** here, so the committable record is the aggregate
+  `docs/studies/closing_data_v2/data/j1_results.json` (+ the reproducer `score_all.py`), not the per-rundir sidecars.
+- Aggregate + decision memo: **[`../../docs/studies/closing_data_v2/JOINT_BEST_RESULTS.md`](../../docs/studies/closing_data_v2/JOINT_BEST_RESULTS.md)**
+  (the corrected table lives in the new `closing_data_v2` study; a §Results pointer was also added to
+  `JOINT_BEST_SCORING.md`).
 - **Response letter:** the honest line is on record in a hidden comment at
   `src/sections/06_results.tex` (search "Response-letter note"): a single joint checkpoint per fold
   exists; numbers can be provided; never claim they match the diag-best cells.

--- a/docs/studies/closing_data/JOINT_BEST_SCORING.md
+++ b/docs/studies/closing_data/JOINT_BEST_SCORING.md
@@ -90,3 +90,14 @@ artifacts when present (and matching selector + min-best-epoch) and prints **per
 - **Do not compare a diag-best cell against a joint-best cell** (or against a single-checkpoint baseline) without
   flagging the convention mismatch — diag-best is an upper bound on the deployable single checkpoint.
 - **Check `min_best_epoch` per run family** before scoring: v17 board = 0; B9-recipe (v11/v12/v15) = 5.
+
+## 6 · Results (J1 executed 2026-07-09) → `docs/studies/closing_data_v2/`
+
+All 18 v17/`dk_ovl` MTL rundirs were joint-best-scored (AL/AZ/FL/Istanbul n=20, CA/TX seed-0 5f). **The served
+single checkpoint reproduces the diag-best Table 3 within ≤ 0.06 pp (category) / ≤ 0.11 pp (region) on every
+dataset (largest deviations 0.051 / 0.107, both at AZ); no verdict changes.** cat beats everywhere; reg beats at Istanbul/FL/TX/CA (Istanbul +0.28→+0.19, still
+positive and 20/20 folds) and matches at AL/AZ (AL −0.31→−0.41, far inside the ±2 pp bound — the flagged AL tail
+risk did not materialize). Validated by three parity gates (diag-best 18/18, joint-epoch 90/90, paper 6/6) + a
+4-agent independent audit (from-scratch re-derivation bit-identical to 4 dp). Full corrected table, Δ-vs-ceiling
+analysis, decision memo, provenance, and audit: **[`../closing_data_v2/`](../closing_data_v2/)**
+(`JOINT_BEST_RESULTS.md` is the table; `data/j1_results.json` + `score_all.py` reproduce it).

--- a/docs/studies/closing_data/v17_completion/README.md
+++ b/docs/studies/closing_data/v17_completion/README.md
@@ -53,7 +53,7 @@
 | **M3** | Bridging-metrics re-score (reg Acc@1/@5/MRR; cat Acc@1) | M2 Pro | open | short (needs saved logits) | nothing (coverage) |
 | **M4** | STAN precision-mix disclosure + v4-collapse guard (now incl. the CA/TX v6-p10 partials) | M2 Pro | open (doc) | doc | STAN hygiene |
 | **M5** | Stale-doc fixes + submission mechanics | M2 Pro | open (doc) | doc | submission |
-| **J1** | **Joint-best re-score of the board rundirs** via `scripts/closing_data/score_joint_best.py` (Table 3 = per-task diag-best, disclosed §6.2; joint-best = the single-checkpoint lane — see [`../JOINT_BEST_SCORING.md`](../JOINT_BEST_SCORING.md)): perhead_lr_n20 AL/AZ/FL, catx_v17_seed0_5f (+ CA/TX n=20 after A1), h3_istanbul | whichever machine holds each rundir (A40; CPU-only) | open | minutes | camera-ready / response letter — NOT the submission |
+| **J1** | **Joint-best re-score of the board rundirs** via `scripts/closing_data/score_joint_best.py` (Table 3 = per-task diag-best, disclosed §6.2; joint-best = the single-checkpoint lane — see [`../JOINT_BEST_SCORING.md`](../JOINT_BEST_SCORING.md)): perhead_lr_n20 AL/AZ/FL, catx_v17_seed0_5f (+ CA/TX n=20 after A1), h3_istanbul | A40 (CPU-only) | ✅ **DONE 2026-07-09** → [`../../closing_data_v2/`](../../closing_data_v2/) (served checkpoint reproduces Table 3 within ≤0.11 pp; no verdict changes; CA/TX still seed-0 pending A1) | minutes | camera-ready / response letter — NOT the submission |
 
 **The critical path to a paper-grade v17 board:** **A1 (CA/TX MTL n=20, A40)** → **M1 full** (all 6 datasets n=20,
 drop "provisional" everywhere). The ceilings + Istanbul are already done; **M1-partial can run NOW** on

--- a/docs/studies/closing_data_v2/AUDIT.md
+++ b/docs/studies/closing_data_v2/AUDIT.md
@@ -1,0 +1,61 @@
+# AUDIT — independent verification of the J1 joint-best re-score
+
+> Four independent verifier agents, each reading the A40 rundirs directly, all returned **CONFIRMED** with
+> **no material discrepancies**. This is on top of the three self-audits built into the scorer
+> (`JOINT_BEST_RESULTS.md §Audit`: diag-best parity 18/18, joint-epoch fidelity 90/90, paper parity 6/6).
+> Workflow: `wf_8392161a-943` (5 agents, 0 errors, 315k subagent tokens).
+
+## 1 · Independent re-derivation (no scorer, no `scoring.py`) — CONFIRMED
+A verifier re-implemented joint-best from scratch (stdlib-only python, own argmax over
+`sqrt(f1·top10_acc_indist)`, ties→earliest) for AL s0, AL s1, Istanbul s0, TX s0, FL s0. **Every per-fold cat
+and reg matched the sidecar bit-identically to 4 dp**, every picked `e*` equalled the sidecar `epochs[]`, and the
+AL s0 fold-1 cross-check held (`primary_checkpoint.epoch` 35 +1 = 36 = e\*). The independent `selector_per_fold`
+reproduced the sidecar exactly → confirms the selector uses `top10_acc_indist` (in-distribution), not full-top10.
+→ **The scorer's logic is independently reproduced; not trusting a single implementation.**
+
+## 2 · AL region tail-risk (the runbook's flagged risk) — CONFIRMED, risk did NOT materialize
+The J1 runbook warned AL region could approach the −2 pp TOST bound (a legacy smoke run once saw −1.16 pp).
+Actual v17 board result over the 4 AL seeds:
+- n=20 joint-best AL reg = **69.695** (cross-seed sd 0.10); diag-best 69.80. **Joint selector penalty = −0.105 pp.**
+- Δ vs ceiling 70.11: **−0.415** (joint) vs −0.310 (diag). **1.585 pp of margin remaining** to the −2 pp bound.
+- **No fold collapse:** all 20 joint epochs 34–49 (min 34); diag reg-best epochs 27–48 (min 27); none ≤ 5.
+- **Worst single-fold joint−diag reg drop = −0.29 pp** (s1 f4) — nowhere near the −1.16 legacy fear.
+→ **AL stays a comfortable within-2-pp match under joint-best.**
+
+## 3 · Istanbul / FL region "beats" sensitivity — CONFIRMED, direction preserved (and per-fold robust)
+The joint-best point estimate is lower, so the up-arrow cells were stress-tested:
+- Istanbul n=20 joint-best reg **75.352** vs ceiling 75.16 → **Δ +0.192** (diag +0.28; thins ~31% relative but **positive**).
+- FL n=20 joint-best reg **77.410** vs ceiling 76.70 → **Δ +0.710** (diag +0.72; essentially unchanged).
+- **Per-fold paired evidence (the strong result):** joint-best MTL reg beats the STL reg ceiling in **20/20 folds**
+  at BOTH states — Istanbul paired diff mean +0.194 (min +0.074, sd 0.082); FL mean +0.712 (min +0.560). A formal
+  Wilcoxon/90%-CI would still reject strongly. **Flip risk LOW even at the thinned Istanbul margin.**
+- Ceilings independently re-derived from the per-fold JSONs: 75.158 / 76.697 (match 75.16 / 76.70).
+- **Metric-definition note for the camera-ready stat (T7):** the MTL side reports FULL top10 = `top10_indist·(1−ood)`
+  while the STL ceiling per-fold JSONs report plain `top10_acc` (ood=None). The board's diag headline already pairs
+  them this way, and MTL beats in 20/20 folds even under the *conservative* FULL metric — but the formal test should
+  confirm both sides use an identical top10 definition. Ceiling per-fold data:
+  `docs/results/P1/region_head_{istanbul,florida}_region_5f_50ep_*_ovl_stl_reg_s{0,1,7,100}.json` (FL {1,7,100}
+  carry a `_topup_` infix); MTL side = `<rundir>/joint_best_score.json → joint_best.reg_per_fold`.
+
+## 4 · Completeness critic — CONFIRMED, scope correct
+- All 6 "Joint (ours)" cells map to the correct v17/`dk_ovl` rundirs (AL/AZ/FL/Istanbul n=20; CA/TX seed-0 5f);
+  all 18 rundirs complete (5 folds, paired CSVs), each now carrying both `a40_matched_score.json` and the new sidecar.
+- **FL uses the `new` bs8192 per-head runs** (diag cat 79.848 = paper 79.85), not the bs2048 `base`.
+- **Recipe verified v17** from `model_params.json`: bs 8192, OneCycle per-head max_lr cat 1e-3 / reg 3e-3 / shared
+  3e-3 (per-head LR APPLIED, not uniform), static_weight 0.75/0.25, AdamW wd 0.05.
+- **CA/TX A1 (n=20) genuinely incomplete on disk:** only a dead CA seed-1 attempt (rundir 742357, 4/5 folds, no
+  sidecar) exists; no CA s7/s100, no TX seeds. `a1_DRIVER.log` shows A1 launched only CA s1 (2026-07-08 19:14) then
+  stopped. → CA/TX correctly stay **seed-0 5f provisional** (task T6 remains blocked on A1).
+- **STL "Dedicated" ceilings need no joint-best re-score** — a single-task checkpoint is picked on that task's own
+  metric = its diag-best (joint-best == diag-best by construction; `score_joint_best.py` can't even run on an STL
+  rundir, it requires paired cat+reg CSVs).
+- Two non-cell CA rundirs correctly excluded from the CA cell: `1342525` (1-fold audit), `742357` (dead A1 s1).
+
+## Forward-looking notes (not defects — for camera-ready / response-letter)
+1. **The §6.2 hidden response-letter note is now STALE.** `articles/[mobiwac]/src/sections/06_results.tex`
+   (lines ~88–93) says the joint-checkpoint numbers "were not re-scored for the paper … do NOT claim they match."
+   J1 has now re-scored them: they land 0.00–0.11 pp below the diag-best cells. When the response letter lands,
+   update the note to cite the actual joint-best numbers (they *confirm* the reported cells, within 0.1 pp).
+2. **If joint-best is ever RENDERED in place of a diag-best cell**, re-verify TOST/CI on the three thin reg cells
+   only (AL −0.42, Istanbul +0.19, AZ −0.00); every cat beat and the FL/TX/CA reg ↑ are safe (task T7).
+3. **CA/TX at n=20** (task T6) is the only genuinely open item, and it is blocked on the A1 GPU top-up, not on J1.

--- a/docs/studies/closing_data_v2/JOINT_BEST_RESULTS.md
+++ b/docs/studies/closing_data_v2/JOINT_BEST_RESULTS.md
@@ -1,0 +1,106 @@
+# JOINT_BEST_RESULTS — the deployable single-checkpoint numbers for Table 3
+
+> **Convention discipline (read once).** Every number here is one of two conventions, always named:
+> **diag-best** = per-task diagnostic-best (cat at its F1-best epoch, reg at its Acc@10-best epoch — *two*
+> epochs/fold; the currently-reported Table 3). **joint-best (deploy)** = the single saved checkpoint, both
+> heads read at the `geom_simple = sqrt(cat_macroF1 · reg_top10_acc_indist)`-selected epoch (`min_best_epoch=0`).
+> Selection logic SSOT: `src/tracking/scoring.py`; scorer `scripts/closing_data/score_joint_best.py`.
+> All cells are **v17 on `check2hgi_dk_ovl`, fp32** — the same runs as Table 3, re-read at one epoch instead of two.
+
+## Headline
+
+**The deployable single checkpoint reproduces the reported Table 3 to within ≤ 0.06 pp (category) and ≤ 0.11 pp
+(region) on every one of the six datasets — the largest deviations are 0.051 pp (category) and 0.107 pp
+(region), both at AZ. No verdict changes.** Category still beats the dedicated ceiling
+everywhere (+5.3 … +9.4); region still beats at Istanbul/FL/TX/CA and stays a within-2-pp match at AL/AZ. The
+diag-best cells are, in practice, exactly what one served model delivers — the diag/joint distinction is
+numerically negligible for these well-converged v17 runs (every joint epoch lands late, 34–50 of 50).
+
+## The corrected table (diag-best vs joint-best, side by side)
+
+Category = macro-F1, region = Acc@10 (FULL = top10_acc_indist·(1−ood_frac)). "Dedicated" = the n=20 best-vs-best
+single-task ceiling (`CEILINGS_N20_FINAL.md`, unchanged). n=20 = 4 seeds {0,1,7,100}×5f (± cross-seed sd);
+CA/TX = seed-0 ×5f provisional (± fold sd).
+
+### Next-category (macro-F1)
+| Dataset | Regions | Dedicated | Joint **diag-best** | Joint **joint-best (deploy)** | Δdeploy−diag |
+|---|---:|---:|---:|---:|---:|
+| Istanbul | 520 | 54.74 | 63.33 ±0.02 | **63.32 ±0.02** | −0.01 |
+| AL | 1,109 | 56.82 | 64.54 ±0.10 | **64.51 ±0.09** | −0.04 |
+| AZ | 1,547 | 56.43 | 65.84 ±0.02 | **65.79 ±0.02** | −0.05 |
+| FL | 4,703 | 74.51 | 79.85 ±0.03 | **79.84 ±0.02** | −0.01 |
+| TX | 6,553 | 69.79 | 77.23 ±0.12 | **77.23 ±0.12** | −0.00 |
+| CA | 8,501 | 70.60 | 77.04 ±0.20 | **77.04 ±0.20** | −0.00 |
+
+### Next-region (Acc@10)
+| Dataset | Regions | Dedicated | Joint **diag-best** | Joint **joint-best (deploy)** | Δdeploy−diag |
+|---|---:|---:|---:|---:|---:|
+| Istanbul | 520 | 75.16 | 75.44 ±0.04 | **75.35 ±0.04** | −0.09 |
+| AL | 1,109 | 70.11 | 69.80 ±0.05 | **69.70 ±0.09** | −0.11 |
+| AZ | 1,547 | 59.46 | 59.56 ±0.05 | **59.46 ±0.04** | −0.11 |
+| FL | 4,703 | 76.70 | 77.42 ±0.03 | **77.41 ±0.02** | −0.01 |
+| TX | 6,553 | 64.95 | 67.07 ±0.45 | **67.07 ±0.45** | −0.00 |
+| CA | 8,501 | 63.49 | 65.69 ±0.30 | **65.69 ±0.30** | −0.01 |
+
+## Δ vs the dedicated ceiling — does the verdict change?
+
+| Dataset | Δcat diag | Δcat **deploy** | verdict | Δreg diag | Δreg **deploy** | verdict |
+|---|---:|---:|---|---:|---:|---|
+| Istanbul | +8.59 | **+8.58** | beats | +0.28 | **+0.19** | beats (thinner) |
+| AL | +7.72 | **+7.69** | beats | −0.31 | **−0.41** | matches (≪2 pp) |
+| AZ | +9.40 † | **+9.35** | beats | +0.10 | **−0.00** | matches |
+| FL | +5.34 | **+5.33** | beats | +0.72 | **+0.71** | beats |
+| TX | +7.44 | **+7.44** | beats | +2.12 | **+2.12** | beats |
+| CA | +6.44 | **+6.44** | beats | +2.20 | **+2.20** | beats |
+
+† AZ diag Δcat: **+9.40** is the paper/board value (from the rounded 65.83 MTL cell, `CEILINGS_N20_FINAL.md`);
+the full-precision Δ from these cells (65.835 − 56.43) is **+9.41**, which is what `score_all.py` / `j1_results.json`
+print. Same 0.01-pp rounding wobble as the paper's own prose. The AZ cat ceiling itself carries a pending 2-seed
+top-up that could raise it to ~57.0 (Δcat → ~+8.8) — a live paper caveat, unrelated to joint-best.
+
+**Every Table-3 verdict is preserved under the deployable convention:**
+- **Category — beats at all six** (+5.33 … +9.35). The joint checkpoint costs ≤ 0.051 pp of category vs diag-best.
+- **Region — beats at Istanbul / FL / TX / CA; matches (TOST, ±2 pp) at AL / AZ.** Direction unchanged everywhere.
+
+Two cells to keep honest (both still on the correct side of their claim):
+1. **Istanbul region** thins from +0.28 to **+0.19** (still a positive point estimate; still "beats"). This is
+   the single most margin-sensitive cell. The independent audit went to the per-fold pairs: the joint-best MTL reg
+   still beats the STL ceiling in **20/20 folds** (min +0.074, mean +0.194) — so a formal Wilcoxon/90%-CI would
+   still reject. The camera-ready superiority stat should be re-run on the joint-best per-fold pairs (task **T7**);
+   the *direction* is preserved and per-fold-robust.
+2. **AZ region** moves +0.10 → **−0.00** — but AZ was always a *match*, never a beat (the paper never bolds it),
+   so the claim is unchanged. **AL region** moves −0.31 → **−0.41**: the J1 runbook flagged AL as the tail risk
+   (a legacy smoke run once saw −1.16); the actual v17 joint-best drop is **−0.11 pp**, landing at −0.41 —
+   **nowhere near the −2 pp non-inferiority bound.** The tail risk did not materialize.
+
+## Audit — three parity gates (all pass)
+
+| Gate | What it proves | Result |
+|---|---|---|
+| **A · diag-best parity** | scorer's diag-best re-derivation == each rundir's committed `a40_matched_score.json` | **18/18 exact** |
+| **B · joint-epoch fidelity** | scorer's `e*` == training's `folds/foldN_info.json → primary_checkpoint.epoch` (+1 for 1-based-CSV vs 0-based-loop) | **90/90 folds** |
+| **C · paper parity** | aggregated diag-best cell == paper `tbl3_results.tex` | **6/6 exact to 2 dp** |
+
+Gate B was verified down to the value: AL s0 fold-1 training checkpoint (epoch 35, 0-based; cat_f1 0.6455,
+reg_top10_indist 0.7241, joint_score 0.6837) == CSV epoch 36 (1-based; identical cat_f1 / indist / geom
+0.683666) == sidecar `selector_per_fold[0]`. The joint-best re-score recovers the *exact* checkpoint the training
+gate saved — no retraining, no GPU. No fold collapsed (every joint epoch 34–50; no reg best-epoch ≤ 5).
+
+Independent adversarial audit (from-scratch re-derivation, AL tail-risk, Istanbul/FL sensitivity, completeness):
+see [`AUDIT.md`](AUDIT.md).
+
+## Decision memo
+
+- **The gap is closed and it is benign.** The served single checkpoint delivers the reported Table 3 within
+  ≤ 0.11 pp; the response-letter can now state this as fact instead of "can be provided on request."
+- **Recommended camera-ready action** (author's call): either (a) keep Table 3 as diag-best and add one sentence
+  in §6.2 — "the single served checkpoint reproduces these cells within 0.1 pp (deployable joint-best,
+  `geom_simple` selector)"; or (b) add a joint-best row/column. Numbers for both are here.
+- **What must travel with these numbers:** always name the convention; the CA/TX cells are seed-0 provisional
+  (T6, blocked on A1 n=20); the Istanbul region superiority stat wants a joint-best re-run (T7); AL/AZ region are
+  *matches*, never beats.
+
+## Files
+- `data/j1_results.json` — per-run + per-cell machine-readable results (incl. per-fold arrays, epochs, audits).
+- `score_all.py` — the reproducer (runs the scorer on all 18 rundirs + all parity gates).
+- `PROVENANCE.md` — the rundir→cell map. `AUDIT.md` — the independent audit. `TASKS.md` — the charter.

--- a/docs/studies/closing_data_v2/PROVENANCE.md
+++ b/docs/studies/closing_data_v2/PROVENANCE.md
@@ -1,0 +1,64 @@
+# PROVENANCE — the 18 v17/dk_ovl MTL rundirs behind Table 3
+
+Every "Joint (ours)" cell in the paper's Table 3 traces to these rundirs on the A40 checkout
+(`/home/vitor.oliveira/PoiMtlNet`, branch `closing-data/v17-ceilings-n20`). They are keyed by the
+launcher **PID** (the safe mapping — never `ls -dt | head`, which races under concurrency). Each was
+independently confirmed by its own `a40_matched_score.json` `"seed"` field. Path prefix:
+`results/check2hgi_dk_ovl/<state>/mtlnet_lr1.0e-04_bs8192_ep50_<ts>_<PID>`.
+
+## Rundir map
+
+| Dataset | seed | PID | driver / doc | verified |
+|---|---:|---:|---|---|
+| Istanbul | 0 | 3852943 | `v17_completion/h3_istanbul` (`run_step3_n20.sh`) | cat 63.318 / reg 75.407 ✓ |
+| Istanbul | 1 | 3858409 | " | cat 63.332 / reg 75.484 ✓ |
+| Istanbul | 7 | 3863852 | " | cat 63.359 / reg 75.392 ✓ |
+| Istanbul | 100 | 3869098 | " | cat 63.306 / reg 75.477 ✓ |
+| Alabama | 0 | 983885 | `perhead_lr_n20` (`run_n20_perhead.sh`, recipe `new`) | cat 64.584 / reg 69.862 ✓ |
+| Alabama | 1 | 983884 | " | cat 64.669 / reg 69.719 ✓ |
+| Alabama | 7 | 988104 | " | cat 64.404 / reg 69.813 ✓ |
+| Alabama | 100 | 988155 | " | cat 64.505 / reg 69.809 ✓ |
+| Arizona | 0 | 992231 | `perhead_lr_n20` (recipe `new`) | cat 65.832 / reg 59.621 ✓ |
+| Arizona | 1 | 992283 | " | cat 65.806 / reg 59.532 ✓ |
+| Arizona | 7 | 998602 | " | cat 65.851 / reg 59.606 ✓ |
+| Arizona | 100 | 998757 | " | cat 65.852 / reg 59.493 ✓ |
+| Florida | 0 | 1058652 | `perhead_lr_n20` (recipe **`new`** = bs8192, NOT `base` bs2048) | cat 79.844 / reg 77.391 ✓ |
+| Florida | 1 | 1088683 | " | cat 79.806 / reg 77.420 ✓ |
+| Florida | 7 | 1097178 | " | cat 79.885 / reg 77.413 ✓ |
+| Florida | 100 | 1119752 | " | cat 79.857 / reg 77.460 ✓ |
+| California | 0 | 1363454 | `catx_v17_seed0_5f` (v17, fp32) | cat 77.042 / reg 65.694 ✓ |
+| Texas | 0 | 1419069 | `catx_v17_seed0_5f` (v17, fp32) | cat 77.227 / reg 67.072 ✓ |
+
+`(cat/reg above = the committed diag-best fold-mean from each rundir's a40_matched_score.json — our scorer's
+diag-best re-derivation reproduces every one of them exactly; that is parity-gate A.)`
+
+**Excluded:** `results/check2hgi_dk_ovl/istanbul/mtlnet_..._341087` — tag `istanbul_cascade_v17_s0`, the P6
+**cascade** ablation (cross-attention disabled). Not the champion MTL; not a Table-3 cell.
+
+## Recipe (identical across the 18, per `run_n20_perhead.sh` / the catx + h3 drivers)
+```
+--task mtl --canon none --task-set check2hgi_next_region --engine check2hgi_dk_ovl
+--epochs 50 --folds 5 --batch-size 8192
+--mtl-loss static_weight --category-weight 0.75 --no-reg-class-weights --no-cat-class-weights
+--cat-head next_gru --reg-head next_stan_flow_dualtower
+--reg-head-param raw_embed_dim=64 fusion_mode=aux freeze_alpha=True alpha_init=0.0   (region prior OFF)
+--task-a-input-type checkin --task-b-input-type region --log-t-kd-weight 0.0
+--scheduler onecycle --max-lr 3e-3 --cat-lr 1e-3 --reg-lr 3e-3 --shared-lr 3e-3   (v17 per-head LR)
+--model mtlnet_crossattn_dualtower --compile --tf32
+MTL_DISABLE_AMP=1 (fp32), MTL_ONECYCLE_PER_HEAD_LR=1, MTL_STRICT=1, --no-checkpoints
+```
+`geom_simple` checkpoint selector (default), `--min-best-epoch` unset → `ExperimentConfig` default **0**
+(the scorer's default matches; `JOINT_BEST_SCORING.md §1`). `--no-checkpoints` skipped saving *weights*, but
+`folds/foldN_info.json → primary_checkpoint.epoch` still records the joint-checkpoint epoch → parity-gate B works.
+
+## How each cell aggregates
+- **n=20 (Istanbul, AL, AZ, FL):** cell = mean over the 4 seeds of each rundir's 5-fold mean; ± = cross-seed
+  pstdev of the 4 per-seed means. (Matches the paper's "± is sd across seeds for four-seed cells".)
+- **seed-0 5f (CA, TX):** cell = the single rundir's 5-fold mean; ± = fold pstdev. (Provisional; A1 n=20 pending.)
+
+## Reproduce
+```bash
+# from the joint-result worktree (has the standardized src/tracking/scoring.py + score_joint_best.py):
+/home/vitor.oliveira/.venv/bin/python docs/studies/closing_data_v2/score_all.py
+# -> writes joint_best_score.json into each rundir + data/j1_results.json here, and prints all parity gates.
+```

--- a/docs/studies/closing_data_v2/README.md
+++ b/docs/studies/closing_data_v2/README.md
@@ -1,0 +1,37 @@
+# closing_data_v2 — the deployable joint-checkpoint lane (J1)
+
+> **What this study is.** A CPU-only, no-retraining follow-up to `closing_data` that answers one question the
+> MobiWac author flagged: *what does the single served checkpoint actually deliver, vs the per-task
+> diagnostic-best cells reported in Table 3?* It re-reads the **same v17 / `check2hgi_dk_ovl` runs** behind
+> Table 3 at the one `geom_simple`-selected epoch (the "joint-best" / deployable convention) and audits the
+> result. This is the J1 lane of [`J1_JOINT_SCORE_RUNBOOK.md`](../../../articles/%5Bmobiwac%5D/J1_JOINT_SCORE_RUNBOOK.md),
+> executed and closed.
+
+## Status: ✅ CLOSED — gap closed, benign.
+
+**The deployable single checkpoint reproduces the reported Table 3 within ≤ 0.06 pp (category) / ≤ 0.11 pp
+(region) on all six datasets — largest deviations 0.051 (category) and 0.107 (region), both at AZ. No verdict
+changes.** Category beats the dedicated ceiling everywhere (+5.3 … +9.4); region beats at Istanbul/FL/TX/CA and
+matches (TOST, ±2 pp) at AL/AZ — identical to Table 3. The AL-region tail risk the runbook warned about did
+**not** materialize (joint-best drop is −0.11 pp; the cell sits at −0.41, far from the −2 pp bound). **CA/TX are
+seed-0 ×5f provisional** (n=20 blocked on the A1 GPU top-up, which is incomplete on disk — not on J1).
+
+## Read in this order
+1. [`TASKS.md`](TASKS.md) — the charter: objective + scope guardrails + task list.
+2. [`JOINT_BEST_RESULTS.md`](JOINT_BEST_RESULTS.md) — **the corrected table** (diag-best vs joint-best,
+   Δ vs ceilings both ways), the three parity gates, and the decision memo.
+3. [`AUDIT.md`](AUDIT.md) — the independent adversarial audit (from-scratch re-derivation + tail-risk +
+   sensitivity + completeness critic).
+4. [`PROVENANCE.md`](PROVENANCE.md) — the 18 rundirs (state, seed, PID, path) and how the cells aggregate.
+5. `data/j1_results.json` + `score_all.py` — machine-readable results + the reproducer.
+
+## Scope (do not drift)
+v17 model (v16 + bs8192 + per-head cat-lr 1e-3), `check2hgi_dk_ovl` overlap-gated substrate, fp32, `geom_simple`
+selector, `min_best_epoch=0` — **the exact Table-3 configuration**. Same rundirs, same ceilings
+(`CEILINGS_N20_FINAL.md`), no new training. We report nothing on a different version, substrate, or ceiling set.
+
+## Relationship to `closing_data`
+`closing_data` (the parent study, `closing-data/v17-ceilings-n20` branch) produced Table 3 as **diag-best**.
+`closing_data_v2` adds the **joint-best / deployable** reading of the identical runs. The convention contract
+both studies share is [`../closing_data/JOINT_BEST_SCORING.md`](../closing_data/JOINT_BEST_SCORING.md). Nothing
+here supersedes a `closing_data` number — it annotates the six MTL cells with their served-checkpoint value.

--- a/docs/studies/closing_data_v2/TASKS.md
+++ b/docs/studies/closing_data_v2/TASKS.md
@@ -1,0 +1,63 @@
+# closing_data_v2 — Task list & objective
+
+> **Read this first.** This is the charter for `closing_data_v2`. It exists so the work does not drift.
+> Everything here is scoped to the **v17** model on the **`check2hgi_dk_ovl`** (overlap-gated, stride-1,
+> MIN_SEQ=10) substrate — the exact configuration behind the MobiWac Table 3. **We report nothing on a
+> different model version, substrate, or ceiling set.** The runs live on the `closing-data/v17-ceilings-n20`
+> branch / A40 checkout; this study only re-reads and re-scores them (CPU-only, no retraining).
+
+## Objective (one sentence)
+
+Produce and audit the **joint-best** (single deployable checkpoint) numbers for the six Table-3 "Joint (ours)"
+MTL cells — the numbers the *one* saved checkpoint per fold actually delivers, both heads read at the
+`geom_simple`-selected epoch — and present them side-by-side with the currently-reported **per-task
+diagnostic-best** cells, so the camera-ready / response-letter can state the deployable numbers honestly and
+**close the diag-best-vs-joint-best gap** the author flagged (`J1_JOINT_SCORE_RUNBOOK.md`).
+
+### Why this gap exists (the one-paragraph background)
+Table 3's MTL cells are **diagnostic-best**: category is read at its own macro-F1-best epoch and region at its
+own Acc@10-best epoch — *two different epochs per fold*. That is an honest per-head headroom number, but it is
+**not a single served model**. Training also saves **one joint checkpoint per fold**, gated on
+`geom_simple = sqrt(cat_macroF1 · reg_top10_acc_indist)` on validation. Nobody had scored it. The paper §6.2
+disclosure sentence was removed (author decision 2026-07-09) and a hidden response-letter note says the joint
+checkpoint "was not re-scored … can be provided on request; do NOT claim they match." **This study provides it.**
+
+## Scope guardrails (do NOT violate)
+- **Model = v17** (= v16 + `--batch-size 8192` + `--onecycle-per-head-lr`, cat/reg/shared 1e-3/3e-3/1e-3).
+- **Substrate = `check2hgi_dk_ovl`** (gated stride-1 overlap, MIN_SEQ=10). fp32. `geom_simple` selector, `min_best_epoch=0`.
+- **Same rundirs as Table 3** — AL/AZ/FL n=20 (`perhead_lr_n20`), CA/TX seed-0 5f (`catx_v17_seed0_5f`),
+  Istanbul n=20 (`h3_istanbul`). No new training. No re-tuned ceilings (the n=20 best-vs-best ceilings from
+  `CEILINGS_N20_FINAL.md` stand).
+- **Never report an MTL number without its epoch-selection convention** (diag-best vs joint-best) — the root
+  cause of the original confusion (`JOINT_BEST_SCORING.md §5`).
+- STL "Dedicated" ceilings need **no** joint-best re-score: a single-task run's saved checkpoint *is* its
+  diag-best (one head, one best epoch). Joint-best applies only to the MTL cells.
+
+## Task list
+
+- [x] **T1 — Map & verify the 18 v17 MTL rundirs.** AL×4, AZ×4, FL×4 (the `new` bs8192 per-head runs, not
+  `base`), CA×1, TX×1, Istanbul×4. Authoritative (state, seed)↔rundir map via PID + each rundir's
+  `a40_matched_score.json` "seed". Exclude the Istanbul cascade run (`341087`). All carry 5 per-epoch CSVs. → `PROVENANCE.md`.
+- [x] **T2 — Run `score_joint_best.py` on all 18 rundirs + aggregate to cells.** Sidecars written into each
+  rundir. n=20 cell = mean over 4 seeds of the per-seed fold-mean (cross-seed sd); CA/TX = single-seed fold-mean
+  (fold sd). → `JOINT_BEST_RESULTS.md`, `data/j1_results.json`.
+- [x] **T3 — Three built-in parity gates.** (A) scorer diag-best == committed `a40_matched_score.json` (18/18);
+  (B) scorer `e*` == training `primary_checkpoint.epoch` (all 90 folds, +1 indexing); (C) diag-best cell ==
+  paper Table 3 (6/6). → `JOINT_BEST_RESULTS.md §Audit`.
+- [x] **T4 — Independent adversarial audit (agent fan-out).** From-scratch re-derivation (no scorer/scoring.py),
+  AL region tail-risk, Istanbul/FL region-margin sensitivity, completeness critic. → `AUDIT.md`.
+- [x] **T5 — Corrected table + decision memo.** Side-by-side diag-best vs joint-best, Δ vs ceilings under both
+  conventions, does any verdict change? → `JOINT_BEST_RESULTS.md`.
+- [ ] **T6 (deferred, GPU) — CA/TX joint-best at n=20.** Blocked on **A1** (CA/TX v17 MTL n=20, seeds {1,7,100});
+  the top-up is incomplete on disk. When A1 lands, re-run T2 on the CA/TX n=20 rundirs and drop "provisional".
+- [ ] **T7 (deferred, CPU) — camera-ready stats on joint-best per-fold pairs.** The paper's region-superiority
+  (Wilcoxon 90% CI) + AL/AZ non-inferiority (TOST) were run on diag-best per-fold pairs. For the camera-ready
+  joint-best row, re-run `superiority_wilcoxon.py` / `region_match_tost.py` on the joint-best per-fold series.
+  Only Istanbul reg (margin +0.28→+0.19) is plausibly sensitive; direction is preserved.
+
+## Deliverables
+- `README.md` — landing + headline finding.
+- `JOINT_BEST_RESULTS.md` — the corrected table, Δ analysis, decision memo, parity gates.
+- `PROVENANCE.md` — the 18 rundirs (state, seed, PID, path) + how the cells aggregate.
+- `AUDIT.md` — the independent adversarial-audit verdicts.
+- `data/j1_results.json` + `score_all.py` — the machine-readable results + the reproducer.

--- a/docs/studies/closing_data_v2/data/j1_results.json
+++ b/docs/studies/closing_data_v2/data/j1_results.json
@@ -1,0 +1,1274 @@
+{
+  "per_run": [
+    {
+      "state": "alabama",
+      "seed": 0,
+      "pid": 983885,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/alabama/mtlnet_lr1.0e-04_bs8192_ep50_20260629_235217_983885",
+      "jb_cat": 64.5279,
+      "jb_reg": 69.8347,
+      "jb_cat_folds": [
+        64.5533,
+        65.8806,
+        66.0597,
+        65.3455,
+        60.8006
+      ],
+      "jb_reg_folds": [
+        71.9128,
+        68.885,
+        73.3766,
+        70.7791,
+        64.2201
+      ],
+      "jb_epochs": [
+        36,
+        40,
+        41,
+        40,
+        45
+      ],
+      "db_cat": 64.584,
+      "db_reg": 69.8617,
+      "delta_cat": -0.0561,
+      "delta_reg": -0.027,
+      "audit_a": {
+        "cat_scorer": 64.584,
+        "cat_a40": 64.584,
+        "reg_scorer": 69.8617,
+        "reg_a40": 69.8617,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 36,
+          "2": 40,
+          "3": 41,
+          "4": 40,
+          "5": 45
+        },
+        "ckpt_epochs": {
+          "1": 35,
+          "2": 39,
+          "3": 40,
+          "4": 39,
+          "5": 44
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "alabama",
+      "seed": 1,
+      "pid": 983884,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/alabama/mtlnet_lr1.0e-04_bs8192_ep50_20260629_235217_983884",
+      "jb_cat": 64.6409,
+      "jb_reg": 69.6012,
+      "jb_cat_folds": [
+        64.9774,
+        65.5216,
+        66.0977,
+        65.3648,
+        61.2431
+      ],
+      "jb_reg_folds": [
+        71.6792,
+        68.5868,
+        73.2766,
+        71.4026,
+        63.0606
+      ],
+      "jb_epochs": [
+        42,
+        36,
+        43,
+        43,
+        38
+      ],
+      "db_cat": 64.6689,
+      "db_reg": 69.7185,
+      "delta_cat": -0.028,
+      "delta_reg": -0.1173,
+      "audit_a": {
+        "cat_scorer": 64.6689,
+        "cat_a40": 64.6689,
+        "reg_scorer": 69.7185,
+        "reg_a40": 69.7185,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 42,
+          "2": 36,
+          "3": 43,
+          "4": 43,
+          "5": 38
+        },
+        "ckpt_epochs": {
+          "1": 41,
+          "2": 35,
+          "3": 42,
+          "4": 42,
+          "5": 37
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "alabama",
+      "seed": 7,
+      "pid": 988104,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/alabama/mtlnet_lr1.0e-04_bs8192_ep50_20260630_001556_988104",
+      "jb_cat": 64.3847,
+      "jb_reg": 69.7018,
+      "jb_cat_folds": [
+        64.5883,
+        65.4239,
+        65.6311,
+        65.1602,
+        61.12
+      ],
+      "jb_reg_folds": [
+        71.7882,
+        68.5664,
+        72.7523,
+        71.4486,
+        63.9535
+      ],
+      "jb_epochs": [
+        45,
+        38,
+        37,
+        49,
+        38
+      ],
+      "db_cat": 64.4041,
+      "db_reg": 69.8129,
+      "delta_cat": -0.0194,
+      "delta_reg": -0.1111,
+      "audit_a": {
+        "cat_scorer": 64.4041,
+        "cat_a40": 64.4041,
+        "reg_scorer": 69.8129,
+        "reg_a40": 69.8129,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 45,
+          "2": 38,
+          "3": 37,
+          "4": 49,
+          "5": 38
+        },
+        "ckpt_epochs": {
+          "1": 44,
+          "2": 37,
+          "3": 36,
+          "4": 48,
+          "5": 37
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "alabama",
+      "seed": 100,
+      "pid": 988155,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/alabama/mtlnet_lr1.0e-04_bs8192_ep50_20260630_001556_988155",
+      "jb_cat": 64.4668,
+      "jb_reg": 69.644,
+      "jb_cat_folds": [
+        64.9432,
+        65.3451,
+        65.6553,
+        65.3663,
+        61.0242
+      ],
+      "jb_reg_folds": [
+        71.3003,
+        68.7931,
+        73.126,
+        71.3922,
+        63.6081
+      ],
+      "jb_epochs": [
+        40,
+        39,
+        39,
+        34,
+        35
+      ],
+      "db_cat": 64.505,
+      "db_reg": 69.809,
+      "delta_cat": -0.0382,
+      "delta_reg": -0.1651,
+      "audit_a": {
+        "cat_scorer": 64.505,
+        "cat_a40": 64.505,
+        "reg_scorer": 69.809,
+        "reg_a40": 69.809,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 40,
+          "2": 39,
+          "3": 39,
+          "4": 34,
+          "5": 35
+        },
+        "ckpt_epochs": {
+          "1": 39,
+          "2": 38,
+          "3": 38,
+          "4": 33,
+          "5": 34
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "arizona",
+      "seed": 0,
+      "pid": 992231,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/arizona/mtlnet_lr1.0e-04_bs8192_ep50_20260630_003956_992231",
+      "jb_cat": 65.7914,
+      "jb_reg": 59.4838,
+      "jb_cat_folds": [
+        67.3288,
+        64.8296,
+        66.7106,
+        65.3408,
+        64.7472
+      ],
+      "jb_reg_folds": [
+        62.7641,
+        59.322,
+        59.6306,
+        57.7466,
+        57.9556
+      ],
+      "jb_epochs": [
+        38,
+        40,
+        37,
+        34,
+        35
+      ],
+      "db_cat": 65.8321,
+      "db_reg": 59.6212,
+      "delta_cat": -0.0407,
+      "delta_reg": -0.1374,
+      "audit_a": {
+        "cat_scorer": 65.8321,
+        "cat_a40": 65.8321,
+        "reg_scorer": 59.6212,
+        "reg_a40": 59.6212,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 38,
+          "2": 40,
+          "3": 37,
+          "4": 34,
+          "5": 35
+        },
+        "ckpt_epochs": {
+          "1": 37,
+          "2": 39,
+          "3": 36,
+          "4": 33,
+          "5": 34
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "arizona",
+      "seed": 1,
+      "pid": 992283,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/arizona/mtlnet_lr1.0e-04_bs8192_ep50_20260630_003956_992283",
+      "jb_cat": 65.7714,
+      "jb_reg": 59.45,
+      "jb_cat_folds": [
+        66.5771,
+        64.8593,
+        66.9116,
+        65.7163,
+        64.7926
+      ],
+      "jb_reg_folds": [
+        62.5675,
+        59.1428,
+        59.5286,
+        58.1821,
+        57.8287
+      ],
+      "jb_epochs": [
+        44,
+        48,
+        35,
+        35,
+        35
+      ],
+      "db_cat": 65.806,
+      "db_reg": 59.5316,
+      "delta_cat": -0.0346,
+      "delta_reg": -0.0816,
+      "audit_a": {
+        "cat_scorer": 65.806,
+        "cat_a40": 65.806,
+        "reg_scorer": 59.5316,
+        "reg_a40": 59.5316,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 44,
+          "2": 48,
+          "3": 35,
+          "4": 35,
+          "5": 35
+        },
+        "ckpt_epochs": {
+          "1": 43,
+          "2": 47,
+          "3": 34,
+          "4": 34,
+          "5": 34
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "arizona",
+      "seed": 7,
+      "pid": 998602,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/arizona/mtlnet_lr1.0e-04_bs8192_ep50_20260630_012450_998602",
+      "jb_cat": 65.7698,
+      "jb_reg": 59.5047,
+      "jb_cat_folds": [
+        66.2852,
+        64.4988,
+        67.5552,
+        65.4953,
+        65.0144
+      ],
+      "jb_reg_folds": [
+        62.5476,
+        59.3718,
+        59.6754,
+        57.866,
+        58.0627
+      ],
+      "jb_epochs": [
+        48,
+        40,
+        39,
+        44,
+        34
+      ],
+      "db_cat": 65.851,
+      "db_reg": 59.6058,
+      "delta_cat": -0.0813,
+      "delta_reg": -0.101,
+      "audit_a": {
+        "cat_scorer": 65.851,
+        "cat_a40": 65.851,
+        "reg_scorer": 59.6058,
+        "reg_a40": 59.6058,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 48,
+          "2": 40,
+          "3": 39,
+          "4": 44,
+          "5": 34
+        },
+        "ckpt_epochs": {
+          "1": 47,
+          "2": 39,
+          "3": 38,
+          "4": 43,
+          "5": 33
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "arizona",
+      "seed": 100,
+      "pid": 998757,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/arizona/mtlnet_lr1.0e-04_bs8192_ep50_20260630_012455_998757",
+      "jb_cat": 65.806,
+      "jb_reg": 59.3872,
+      "jb_cat_folds": [
+        66.365,
+        64.6721,
+        67.3643,
+        65.5796,
+        65.0488
+      ],
+      "jb_reg_folds": [
+        63.0777,
+        59.2459,
+        59.1827,
+        57.4369,
+        57.993
+      ],
+      "jb_epochs": [
+        42,
+        37,
+        38,
+        36,
+        36
+      ],
+      "db_cat": 65.8523,
+      "db_reg": 59.4933,
+      "delta_cat": -0.0463,
+      "delta_reg": -0.106,
+      "audit_a": {
+        "cat_scorer": 65.8523,
+        "cat_a40": 65.8523,
+        "reg_scorer": 59.4933,
+        "reg_a40": 59.4933,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 42,
+          "2": 37,
+          "3": 38,
+          "4": 36,
+          "5": 36
+        },
+        "ckpt_epochs": {
+          "1": 41,
+          "2": 36,
+          "3": 37,
+          "4": 35,
+          "5": 35
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "florida",
+      "seed": 0,
+      "pid": 1058652,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/florida/mtlnet_lr1.0e-04_bs8192_ep50_20260630_070822_1058652",
+      "jb_cat": 79.8369,
+      "jb_reg": 77.3862,
+      "jb_cat_folds": [
+        79.4438,
+        79.9507,
+        79.8154,
+        79.3609,
+        80.6137
+      ],
+      "jb_reg_folds": [
+        77.6377,
+        77.498,
+        76.1903,
+        76.5457,
+        79.0594
+      ],
+      "jb_epochs": [
+        44,
+        48,
+        50,
+        49,
+        49
+      ],
+      "db_cat": 79.8443,
+      "db_reg": 77.391,
+      "delta_cat": -0.0074,
+      "delta_reg": -0.0048,
+      "audit_a": {
+        "cat_scorer": 79.8443,
+        "cat_a40": 79.8443,
+        "reg_scorer": 77.391,
+        "reg_a40": 77.391,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 44,
+          "2": 48,
+          "3": 50,
+          "4": 49,
+          "5": 49
+        },
+        "ckpt_epochs": {
+          "1": 43,
+          "2": 47,
+          "3": 49,
+          "4": 48,
+          "5": 48
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "florida",
+      "seed": 1,
+      "pid": 1088683,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/florida/mtlnet_lr1.0e-04_bs8192_ep50_20260630_111843_1088683",
+      "jb_cat": 79.8045,
+      "jb_reg": 77.4109,
+      "jb_cat_folds": [
+        78.8264,
+        79.7901,
+        80.2347,
+        79.3312,
+        80.8399
+      ],
+      "jb_reg_folds": [
+        77.3666,
+        76.9029,
+        76.929,
+        76.6846,
+        79.1716
+      ],
+      "jb_epochs": [
+        43,
+        40,
+        47,
+        48,
+        48
+      ],
+      "db_cat": 79.806,
+      "db_reg": 77.4196,
+      "delta_cat": -0.0015,
+      "delta_reg": -0.0086,
+      "audit_a": {
+        "cat_scorer": 79.806,
+        "cat_a40": 79.806,
+        "reg_scorer": 77.4196,
+        "reg_a40": 77.4196,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 43,
+          "2": 40,
+          "3": 47,
+          "4": 48,
+          "5": 48
+        },
+        "ckpt_epochs": {
+          "1": 42,
+          "2": 39,
+          "3": 46,
+          "4": 47,
+          "5": 47
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "florida",
+      "seed": 7,
+      "pid": 1097178,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/florida/mtlnet_lr1.0e-04_bs8192_ep50_20260630_121402_1097178",
+      "jb_cat": 79.87,
+      "jb_reg": 77.3978,
+      "jb_cat_folds": [
+        79.351,
+        79.8604,
+        79.9381,
+        79.2985,
+        80.9022
+      ],
+      "jb_reg_folds": [
+        77.3717,
+        77.1457,
+        76.636,
+        76.7678,
+        79.0677
+      ],
+      "jb_epochs": [
+        44,
+        42,
+        49,
+        47,
+        43
+      ],
+      "db_cat": 79.8847,
+      "db_reg": 77.413,
+      "delta_cat": -0.0147,
+      "delta_reg": -0.0152,
+      "audit_a": {
+        "cat_scorer": 79.8847,
+        "cat_a40": 79.8847,
+        "reg_scorer": 77.413,
+        "reg_a40": 77.413,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 44,
+          "2": 42,
+          "3": 49,
+          "4": 47,
+          "5": 43
+        },
+        "ckpt_epochs": {
+          "1": 43,
+          "2": 41,
+          "3": 48,
+          "4": 46,
+          "5": 42
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "florida",
+      "seed": 100,
+      "pid": 1119752,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/florida/mtlnet_lr1.0e-04_bs8192_ep50_20260630_154208_1119752",
+      "jb_cat": 79.8515,
+      "jb_reg": 77.4439,
+      "jb_cat_folds": [
+        79.112,
+        79.7672,
+        79.6398,
+        79.5206,
+        81.2179
+      ],
+      "jb_reg_folds": [
+        77.1924,
+        77.1029,
+        76.6937,
+        76.8023,
+        79.4282
+      ],
+      "jb_epochs": [
+        50,
+        47,
+        50,
+        47,
+        42
+      ],
+      "db_cat": 79.8572,
+      "db_reg": 77.46,
+      "delta_cat": -0.0056,
+      "delta_reg": -0.0161,
+      "audit_a": {
+        "cat_scorer": 79.8572,
+        "cat_a40": 79.8572,
+        "reg_scorer": 77.46,
+        "reg_a40": 77.46,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 50,
+          "2": 47,
+          "3": 50,
+          "4": 47,
+          "5": 42
+        },
+        "ckpt_epochs": {
+          "1": 49,
+          "2": 46,
+          "3": 49,
+          "4": 46,
+          "5": 41
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "california",
+      "seed": 0,
+      "pid": 1363454,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/california/mtlnet_lr1.0e-04_bs8192_ep50_20260701_040244_1363454",
+      "jb_cat": 77.0406,
+      "jb_reg": 65.6876,
+      "jb_cat_folds": [
+        76.9509,
+        77.2786,
+        76.7003,
+        77.1617,
+        77.1116
+      ],
+      "jb_reg_folds": [
+        65.4044,
+        65.5541,
+        65.6362,
+        65.5725,
+        66.271
+      ],
+      "jb_epochs": [
+        48,
+        48,
+        49,
+        49,
+        49
+      ],
+      "db_cat": 77.0422,
+      "db_reg": 65.694,
+      "delta_cat": -0.0016,
+      "delta_reg": -0.0064,
+      "audit_a": {
+        "cat_scorer": 77.0422,
+        "cat_a40": 77.0422,
+        "reg_scorer": 65.694,
+        "reg_a40": 65.694,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 48,
+          "2": 48,
+          "3": 49,
+          "4": 49,
+          "5": 49
+        },
+        "ckpt_epochs": {
+          "1": 47,
+          "2": 47,
+          "3": 48,
+          "4": 48,
+          "5": 48
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "texas",
+      "seed": 0,
+      "pid": 1419069,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/texas/mtlnet_lr1.0e-04_bs8192_ep50_20260701_085836_1419069",
+      "jb_cat": 77.227,
+      "jb_reg": 67.0711,
+      "jb_cat_folds": [
+        77.4234,
+        77.0575,
+        77.1903,
+        77.2942,
+        77.1695
+      ],
+      "jb_reg_folds": [
+        66.9747,
+        67.3614,
+        66.2423,
+        67.2732,
+        67.5038
+      ],
+      "jb_epochs": [
+        49,
+        50,
+        49,
+        49,
+        50
+      ],
+      "db_cat": 77.2272,
+      "db_reg": 67.0723,
+      "delta_cat": -0.0002,
+      "delta_reg": -0.0012,
+      "audit_a": {
+        "cat_scorer": 77.2272,
+        "cat_a40": 77.2272,
+        "reg_scorer": 67.0723,
+        "reg_a40": 67.0723,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 49,
+          "2": 50,
+          "3": 49,
+          "4": 49,
+          "5": 50
+        },
+        "ckpt_epochs": {
+          "1": 48,
+          "2": 49,
+          "3": 48,
+          "4": 48,
+          "5": 49
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "istanbul",
+      "seed": 0,
+      "pid": 3852943,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/istanbul/mtlnet_lr1.0e-04_bs8192_ep50_20260706_035048_3852943",
+      "jb_cat": 63.3014,
+      "jb_reg": 75.3392,
+      "jb_cat_folds": [
+        64.2416,
+        62.7909,
+        62.7779,
+        63.2525,
+        63.4442
+      ],
+      "jb_reg_folds": [
+        76.6864,
+        75.0888,
+        74.585,
+        75.2379,
+        75.098
+      ],
+      "jb_epochs": [
+        46,
+        40,
+        47,
+        46,
+        47
+      ],
+      "db_cat": 63.3179,
+      "db_reg": 75.4066,
+      "delta_cat": -0.0164,
+      "delta_reg": -0.0674,
+      "audit_a": {
+        "cat_scorer": 63.3179,
+        "cat_a40": 63.3179,
+        "reg_scorer": 75.4066,
+        "reg_a40": 75.4066,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 46,
+          "2": 40,
+          "3": 47,
+          "4": 46,
+          "5": 47
+        },
+        "ckpt_epochs": {
+          "1": 45,
+          "2": 39,
+          "3": 46,
+          "4": 45,
+          "5": 46
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "istanbul",
+      "seed": 1,
+      "pid": 3858409,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/istanbul/mtlnet_lr1.0e-04_bs8192_ep50_20260706_042640_3858409",
+      "jb_cat": 63.3323,
+      "jb_reg": 75.3767,
+      "jb_cat_folds": [
+        62.9587,
+        63.9112,
+        62.9677,
+        63.0428,
+        63.7812
+      ],
+      "jb_reg_folds": [
+        76.1857,
+        75.1863,
+        75.3019,
+        75.8829,
+        74.3268
+      ],
+      "jb_epochs": [
+        45,
+        44,
+        43,
+        47,
+        41
+      ],
+      "db_cat": 63.3323,
+      "db_reg": 75.4835,
+      "delta_cat": 0.0,
+      "delta_reg": -0.1067,
+      "audit_a": {
+        "cat_scorer": 63.3323,
+        "cat_a40": 63.3323,
+        "reg_scorer": 75.4835,
+        "reg_a40": 75.4835,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 45,
+          "2": 44,
+          "3": 43,
+          "4": 47,
+          "5": 41
+        },
+        "ckpt_epochs": {
+          "1": 44,
+          "2": 43,
+          "3": 42,
+          "4": 46,
+          "5": 40
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "istanbul",
+      "seed": 7,
+      "pid": 3863852,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/istanbul/mtlnet_lr1.0e-04_bs8192_ep50_20260706_050236_3863852",
+      "jb_cat": 63.351,
+      "jb_reg": 75.2954,
+      "jb_cat_folds": [
+        63.7864,
+        63.3901,
+        62.7338,
+        63.565,
+        63.2797
+      ],
+      "jb_reg_folds": [
+        75.2765,
+        75.3842,
+        75.4827,
+        74.6797,
+        75.6538
+      ],
+      "jb_epochs": [
+        42,
+        40,
+        49,
+        50,
+        46
+      ],
+      "db_cat": 63.3587,
+      "db_reg": 75.3922,
+      "delta_cat": -0.0077,
+      "delta_reg": -0.0968,
+      "audit_a": {
+        "cat_scorer": 63.3587,
+        "cat_a40": 63.3587,
+        "reg_scorer": 75.3922,
+        "reg_a40": 75.3922,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 42,
+          "2": 40,
+          "3": 49,
+          "4": 50,
+          "5": 46
+        },
+        "ckpt_epochs": {
+          "1": 41,
+          "2": 39,
+          "3": 48,
+          "4": 49,
+          "5": 45
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    },
+    {
+      "state": "istanbul",
+      "seed": 100,
+      "pid": 3869098,
+      "rundir": "/home/vitor.oliveira/PoiMtlNet/results/check2hgi_dk_ovl/istanbul/mtlnet_lr1.0e-04_bs8192_ep50_20260706_053831_3869098",
+      "jb_cat": 63.3,
+      "jb_reg": 75.3966,
+      "jb_cat_folds": [
+        63.0598,
+        63.5183,
+        63.0641,
+        63.4506,
+        63.4071
+      ],
+      "jb_reg_folds": [
+        75.2581,
+        75.2931,
+        75.4735,
+        75.2729,
+        75.6856
+      ],
+      "jb_epochs": [
+        46,
+        48,
+        49,
+        50,
+        48
+      ],
+      "db_cat": 63.3059,
+      "db_reg": 75.4769,
+      "delta_cat": -0.0059,
+      "delta_reg": -0.0802,
+      "audit_a": {
+        "cat_scorer": 63.3059,
+        "cat_a40": 63.3059,
+        "reg_scorer": 75.4769,
+        "reg_a40": 75.4769,
+        "ok": true
+      },
+      "audit_b": {
+        "scorer_epochs": {
+          "1": 46,
+          "2": 48,
+          "3": 49,
+          "4": 50,
+          "5": 48
+        },
+        "ckpt_epochs": {
+          "1": 45,
+          "2": 47,
+          "3": 48,
+          "4": 49,
+          "5": 47
+        },
+        "mismatches": {},
+        "ok": true
+      },
+      "reg_collapse_epochs": [],
+      "warnings": []
+    }
+  ],
+  "cells": {
+    "alabama": {
+      "seeds": [
+        0,
+        1,
+        7,
+        100
+      ],
+      "basis": "n=20 (4 seeds x5f); +/- = cross-seed sd of per-seed means",
+      "jb_cat": 64.5051,
+      "jb_cat_sd": 0.0934,
+      "jb_reg": 69.6954,
+      "jb_reg_sd": 0.088,
+      "db_cat": 64.5405,
+      "db_cat_sd": 0.0978,
+      "db_reg": 69.8005,
+      "db_reg_sd": 0.0517,
+      "paper_diag": [
+        64.54,
+        69.8
+      ],
+      "ceiling": [
+        56.82,
+        70.11
+      ],
+      "jb_dcat_vs_ceil": 7.69,
+      "jb_dreg_vs_ceil": -0.41,
+      "db_dcat_vs_ceil": 7.72,
+      "db_dreg_vs_ceil": -0.31,
+      "gap_cat": -0.035,
+      "gap_reg": -0.105
+    },
+    "arizona": {
+      "seeds": [
+        0,
+        1,
+        7,
+        100
+      ],
+      "basis": "n=20 (4 seeds x5f); +/- = cross-seed sd of per-seed means",
+      "jb_cat": 65.7846,
+      "jb_cat_sd": 0.015,
+      "jb_reg": 59.4564,
+      "jb_reg_sd": 0.0445,
+      "db_cat": 65.8354,
+      "db_cat_sd": 0.0187,
+      "db_reg": 59.563,
+      "db_reg_sd": 0.0526,
+      "paper_diag": [
+        65.84,
+        59.56
+      ],
+      "ceiling": [
+        56.43,
+        59.46
+      ],
+      "jb_dcat_vs_ceil": 9.35,
+      "jb_dreg_vs_ceil": -0.0,
+      "db_dcat_vs_ceil": 9.41,
+      "db_dreg_vs_ceil": 0.1,
+      "gap_cat": -0.051,
+      "gap_reg": -0.107
+    },
+    "florida": {
+      "seeds": [
+        0,
+        1,
+        7,
+        100
+      ],
+      "basis": "n=20 (4 seeds x5f); +/- = cross-seed sd of per-seed means",
+      "jb_cat": 79.8407,
+      "jb_cat_sd": 0.024,
+      "jb_reg": 77.4097,
+      "jb_reg_sd": 0.0216,
+      "db_cat": 79.8481,
+      "db_cat_sd": 0.0283,
+      "db_reg": 77.4209,
+      "db_reg_sd": 0.0249,
+      "paper_diag": [
+        79.85,
+        77.42
+      ],
+      "ceiling": [
+        74.51,
+        76.7
+      ],
+      "jb_dcat_vs_ceil": 5.33,
+      "jb_dreg_vs_ceil": 0.71,
+      "db_dcat_vs_ceil": 5.34,
+      "db_dreg_vs_ceil": 0.72,
+      "gap_cat": -0.007,
+      "gap_reg": -0.011
+    },
+    "california": {
+      "seeds": [
+        0
+      ],
+      "basis": "seed-0 x5f (provisional); +/- = fold sd",
+      "jb_cat": 77.0406,
+      "jb_cat_sd": 0.2001,
+      "jb_reg": 65.6876,
+      "jb_reg_sd": 0.3014,
+      "db_cat": 77.0422,
+      "db_cat_sd": null,
+      "db_reg": 65.694,
+      "db_reg_sd": null,
+      "paper_diag": [
+        77.04,
+        65.69
+      ],
+      "ceiling": [
+        70.6,
+        63.49
+      ],
+      "jb_dcat_vs_ceil": 6.44,
+      "jb_dreg_vs_ceil": 2.2,
+      "db_dcat_vs_ceil": 6.44,
+      "db_dreg_vs_ceil": 2.2,
+      "gap_cat": -0.002,
+      "gap_reg": -0.006
+    },
+    "texas": {
+      "seeds": [
+        0
+      ],
+      "basis": "seed-0 x5f (provisional); +/- = fold sd",
+      "jb_cat": 77.227,
+      "jb_cat_sd": 0.1237,
+      "jb_reg": 67.0711,
+      "jb_reg_sd": 0.4491,
+      "db_cat": 77.2272,
+      "db_cat_sd": null,
+      "db_reg": 67.0723,
+      "db_reg_sd": null,
+      "paper_diag": [
+        77.23,
+        67.07
+      ],
+      "ceiling": [
+        69.79,
+        64.95
+      ],
+      "jb_dcat_vs_ceil": 7.44,
+      "jb_dreg_vs_ceil": 2.12,
+      "db_dcat_vs_ceil": 7.44,
+      "db_dreg_vs_ceil": 2.12,
+      "gap_cat": -0.0,
+      "gap_reg": -0.001
+    },
+    "istanbul": {
+      "seeds": [
+        0,
+        1,
+        7,
+        100
+      ],
+      "basis": "n=20 (4 seeds x5f); +/- = cross-seed sd of per-seed means",
+      "jb_cat": 63.3212,
+      "jb_cat_sd": 0.0215,
+      "jb_reg": 75.352,
+      "jb_reg_sd": 0.0386,
+      "db_cat": 63.3287,
+      "db_cat_sd": 0.0197,
+      "db_reg": 75.4398,
+      "db_reg_sd": 0.0408,
+      "paper_diag": [
+        63.33,
+        75.44
+      ],
+      "ceiling": [
+        54.74,
+        75.16
+      ],
+      "jb_dcat_vs_ceil": 8.58,
+      "jb_dreg_vs_ceil": 0.19,
+      "db_dcat_vs_ceil": 8.59,
+      "db_dreg_vs_ceil": 0.28,
+      "gap_cat": -0.008,
+      "gap_reg": -0.088
+    }
+  },
+  "order": [
+    "istanbul",
+    "alabama",
+    "arizona",
+    "florida",
+    "texas",
+    "california"
+  ]
+}

--- a/docs/studies/closing_data_v2/score_all.py
+++ b/docs/studies/closing_data_v2/score_all.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""J1 joint-best scoring + aggregation for the v17/dk_ovl MobiWac board.
+
+Runs scripts/closing_data/score_joint_best.py (SSOT selection logic) on every
+v17 MTL rundir, then aggregates to Table-3 cells with three built-in audits:
+  (A) scorer diag-best  ==  committed a40_matched_score.json  (per rundir)
+  (B) scorer joint_epoch  ==  folds/foldN_info.json primary_checkpoint.epoch (per fold)
+  (C) diag-best cell  ==  paper tbl3_results.tex rendered value
+
+Reads rundirs from the MAIN checkout; runs the scorer from the WORKTREE (standardized
+src/tracking/scoring.py). CPU-only, no retraining.
+"""
+import json
+import subprocess
+import statistics as st
+from pathlib import Path
+
+MAIN = Path("/home/vitor.oliveira/PoiMtlNet")                       # holds run data
+WORKTREE = Path("/home/vitor.oliveira/PoiMtlNet/.claude/worktrees/joint-result")  # holds scorer
+PY = "/home/vitor.oliveira/.venv/bin/python"
+SCORER = WORKTREE / "scripts/closing_data/score_joint_best.py"
+
+# (state, seed, PID)  -- authoritative mapping verified against summary.tsv + each
+# rundir's a40_matched_score.json "seed" field.
+MANIFEST = [
+    ("alabama",   0,   983885), ("alabama",   1,   983884), ("alabama",   7,   988104), ("alabama",   100, 988155),
+    ("arizona",   0,   992231), ("arizona",   1,   992283), ("arizona",   7,   998602), ("arizona",   100, 998757),
+    ("florida",   0,  1058652), ("florida",   1,  1088683), ("florida",   7,  1097178), ("florida",   100, 1119752),
+    ("california",0,  1363454),
+    ("texas",     0,  1419069),
+    ("istanbul",  0,  3852943), ("istanbul",  1,  3858409), ("istanbul",  7,  3863852), ("istanbul",  100, 3869098),
+]
+
+# Paper tbl3 rendered DIAG-BEST cells (cat, reg) -- the parity-(C) target.
+PAPER_DIAG = {
+    "istanbul":  (63.33, 75.44), "alabama": (64.54, 69.80), "arizona": (65.84, 59.56),
+    "florida":   (79.85, 77.42), "texas":   (77.23, 67.07), "california": (77.04, 65.69),
+}
+# Dedicated ceilings (n=20 best-vs-best, CEILINGS_N20_FINAL.md): (cat, reg)
+CEIL = {
+    "istanbul": (54.74, 75.16), "alabama": (56.82, 70.11), "arizona": (56.43, 59.46),
+    "florida":  (74.51, 76.70), "texas":   (69.79, 64.95), "california": (70.60, 63.49),
+}
+ORDER = ["istanbul", "alabama", "arizona", "florida", "texas", "california"]
+
+
+def find_rundir(state, pid):
+    hits = sorted((MAIN / "results/check2hgi_dk_ovl" / state).glob(f"mtlnet_*_{pid}"))
+    if not hits:
+        raise SystemExit(f"MISSING rundir: {state} pid={pid}")
+    return hits[0]
+
+
+def fold_ckpt_epochs(rundir):
+    """primary_checkpoint.epoch per fold from folds/foldN_info.json (training's joint gate)."""
+    out = {}
+    for f in sorted((rundir / "folds").glob("fold*_info.json")):
+        try:
+            d = json.loads(f.read_text())
+            fn = d.get("fold_number")
+            ep = d.get("primary_checkpoint", {}).get("epoch")
+            if fn is not None and ep is not None:
+                out[int(fn)] = int(ep)
+        except (json.JSONDecodeError, OSError):
+            pass
+    return out
+
+
+def run_one(state, seed, pid):
+    rundir = find_rundir(state, pid)
+    tag = f"{state}_s{seed}"
+    r = subprocess.run([PY, str(SCORER), str(rundir), "--seed", str(seed), "--tag", tag],
+                       capture_output=True, text=True, cwd=str(WORKTREE))
+    if r.returncode != 0:
+        raise SystemExit(f"scorer FAILED for {tag}:\n{r.stderr}\n{r.stdout}")
+    sc = json.loads((rundir / "joint_best_score.json").read_text())
+    a40 = json.loads((rundir / "a40_matched_score.json").read_text())
+    ckpt = fold_ckpt_epochs(rundir)
+
+    # --- audit A: scorer diag-best == committed a40 diag-best
+    audit_a = {
+        "cat_scorer": sc["diag_best"]["cat_macro_f1_mean"], "cat_a40": a40["cat_macro_f1_mean"],
+        "reg_scorer": sc["diag_best"]["reg_full_top10_mean"], "reg_a40": a40["reg_full_top10_mean"],
+    }
+    audit_a["ok"] = (abs(audit_a["cat_scorer"] - audit_a["cat_a40"]) < 0.01 and
+                     abs(audit_a["reg_scorer"] - audit_a["reg_a40"]) < 0.01)
+    # --- audit B: scorer joint_epoch (1-based CSV) == training primary_checkpoint.epoch (0-based loop) + 1.
+    # The +1 is a confirmed indexing convention, not a mismatch (verified: same cat_f1/reg_indist/joint_score).
+    jb_epochs = {row["fold"]: row["joint_best"]["epoch"] for row in sc["per_fold"] if row["joint_best"]}
+    mism = {f: (jb_epochs.get(f), ckpt.get(f)) for f in sorted(set(jb_epochs) & set(ckpt))
+            if jb_epochs[f] != ckpt[f] + 1}
+    audit_b = {"scorer_epochs": jb_epochs, "ckpt_epochs": ckpt, "mismatches": mism, "ok": not mism}
+    # --- collapse tell: reg diag best-epoch <= 5 (precision-collapse signature)
+    collapse = [e for e in sc["diag_best"]["reg_best_epochs"] if e <= 5]
+
+    return {
+        "state": state, "seed": seed, "pid": pid, "rundir": str(rundir),
+        "jb_cat": sc["joint_best"]["cat_macro_f1_mean"], "jb_reg": sc["joint_best"]["reg_full_top10_mean"],
+        "jb_cat_folds": sc["joint_best"]["cat_per_fold"], "jb_reg_folds": sc["joint_best"]["reg_per_fold"],
+        "jb_epochs": sc["joint_best"]["epochs"],
+        "db_cat": sc["diag_best"]["cat_macro_f1_mean"], "db_reg": sc["diag_best"]["reg_full_top10_mean"],
+        "delta_cat": sc["delta_joint_minus_diag"]["cat"], "delta_reg": sc["delta_joint_minus_diag"]["reg"],
+        "audit_a": audit_a, "audit_b": audit_b, "reg_collapse_epochs": collapse,
+        "warnings": sc.get("warnings", []),
+    }
+
+
+def agg(vals):
+    m = st.mean(vals); s = st.pstdev(vals) if len(vals) > 1 else 0.0
+    return round(m, 4), round(s, 4)
+
+
+def main():
+    per_run = [run_one(*m) for m in MANIFEST]
+    by_state = {}
+    for r in per_run:
+        by_state.setdefault(r["state"], []).append(r)
+
+    cells = {}
+    for state, runs in by_state.items():
+        runs.sort(key=lambda r: r["seed"])
+        n_seeds = len(runs)
+        if n_seeds > 1:  # n=20 : mean over per-seed fold-means, cross-seed pstdev
+            jc, jcs = agg([r["jb_cat"] for r in runs]);  jr, jrs = agg([r["jb_reg"] for r in runs])
+            dc, dcs = agg([r["db_cat"] for r in runs]);  dr, drs = agg([r["db_reg"] for r in runs])
+            basis = f"n={n_seeds*5} ({n_seeds} seeds x5f); +/- = cross-seed sd of per-seed means"
+        else:            # single seed : fold-mean already, fold pstdev
+            r0 = runs[0]
+            jc, jcs = agg(r0["jb_cat_folds"]); jr, jrs = agg(r0["jb_reg_folds"])
+            dc, dcs = r0["db_cat"], None; dr, drs = r0["db_reg"], None
+            basis = "seed-0 x5f (provisional); +/- = fold sd"
+        cells[state] = {
+            "seeds": [r["seed"] for r in runs], "basis": basis,
+            "jb_cat": jc, "jb_cat_sd": jcs, "jb_reg": jr, "jb_reg_sd": jrs,
+            "db_cat": dc, "db_cat_sd": dcs, "db_reg": dr, "db_reg_sd": drs,
+            "paper_diag": PAPER_DIAG[state], "ceiling": CEIL[state],
+            "jb_dcat_vs_ceil": round(jc - CEIL[state][0], 2), "jb_dreg_vs_ceil": round(jr - CEIL[state][1], 2),
+            "db_dcat_vs_ceil": round(dc - CEIL[state][0], 2), "db_dreg_vs_ceil": round(dr - CEIL[state][1], 2),
+            "gap_cat": round(jc - dc, 3), "gap_reg": round(jr - dr, 3),
+        }
+
+    out = {"per_run": per_run, "cells": cells, "order": ORDER}
+    outp = WORKTREE / "docs/studies/closing_data_v2/data/j1_results.json"
+    outp.write_text(json.dumps(out, indent=2))
+
+    # ---------- report ----------
+    print("=" * 100)
+    print("AUDIT A (scorer diag-best == committed a40_matched_score.json) + AUDIT B (joint_epoch == training ckpt epoch + 1, indexing)")
+    print("=" * 100)
+    all_ok = True
+    for r in per_run:
+        a, b = r["audit_a"], r["audit_b"]
+        flag = "OK " if (a["ok"] and b["ok"] and not r["reg_collapse_epochs"]) else "!! "
+        if not (a["ok"] and b["ok"]):
+            all_ok = False
+        print(f"{flag}{r['state']:11}s{r['seed']:<4} A:cat {a['cat_scorer']:.3f}/{a['cat_a40']:.3f} "
+              f"reg {a['reg_scorer']:.3f}/{a['reg_a40']:.3f} [{'ok' if a['ok'] else 'MISMATCH'}]"
+              f"  B:{'ok' if b['ok'] else 'MISMATCH '+str(b['mismatches'])}"
+              f"  reg_collapse={r['reg_collapse_epochs'] or '-'}")
+    print(f"\nAll parity A+B OK: {all_ok}\n")
+
+    print("=" * 100)
+    print("CELLS  (JB = joint-best single checkpoint ; DB = diag-best two-epoch ; ceil = dedicated n=20)")
+    print("=" * 100)
+    hdr = f"{'state':11} {'basis':46} {'JBcat':>8} {'DBcat':>8} {'paperC':>7} | {'JBreg':>8} {'DBreg':>8} {'paperR':>7} | {'gapC':>6} {'gapR':>6}"
+    print(hdr)
+    for s in ORDER:
+        c = cells[s]
+        pc, pr = c["paper_diag"]
+        cok = "ok" if abs(c["db_cat"] - pc) < 0.05 else "DIFF"
+        rok = "ok" if abs(c["db_reg"] - pr) < 0.05 else "DIFF"
+        print(f"{s:11} {c['basis']:46} {c['jb_cat']:8.3f} {c['db_cat']:8.3f} {pc:7.2f} | "
+              f"{c['jb_reg']:8.3f} {c['db_reg']:8.3f} {pr:7.2f} | {c['gap_cat']:6.2f} {c['gap_reg']:6.2f}  [C:{cok} R:{rok}]")
+
+    print("\n" + "=" * 100)
+    print("DELTA vs DEDICATED CEILING  --  does the verdict change under joint-best?")
+    print("=" * 100)
+    print(f"{'state':11} {'DBdcat':>7} {'JBdcat':>7} | {'DBdreg':>7} {'JBdreg':>7}   verdict-shift?")
+    for s in ORDER:
+        c = cells[s]
+        print(f"{s:11} {c['db_dcat_vs_ceil']:+7.2f} {c['jb_dcat_vs_ceil']:+7.2f} | "
+              f"{c['db_dreg_vs_ceil']:+7.2f} {c['jb_dreg_vs_ceil']:+7.2f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds the **`closing_data_v2`** study — the **joint-best** (single served checkpoint, `geom_simple`-selected epoch) numbers for the six Table-3 MTL cells, alongside the per-task **diagnostic-best** cells the paper currently reports. Same **v17 / `check2hgi_dk_ovl`** runs behind Table 3, re-read at one epoch instead of two. CPU-only, no retraining. Closes the diag-best-vs-joint-best gap flagged in `J1_JOINT_SCORE_RUNBOOK.md`.

## Finding

**The served single checkpoint reproduces Table 3 within ≤ 0.06 pp (category, max 0.051 at AZ) / ≤ 0.11 pp (region, max 0.107 at AZ) on every dataset. No verdict changes.**

- Category **beats** the dedicated ceiling everywhere (+5.33 … +9.35).
- Region **beats** at Istanbul/FL/TX/CA (Istanbul thins +0.28 → +0.19 but wins **20/20 paired folds**) and **matches** (TOST, ≤ 2 pp) at AL/AZ.
- The AL region tail risk the runbook flagged did **not** materialize (drop −0.11 pp; cell −0.41, far inside the −2 pp bound).
- **CA/TX stay seed-0 provisional** — n=20 is blocked on the A1 GPU top-up (incomplete on disk), not on J1.

## Validation

- **3 self-audits:** diag-best parity **18/18** (== committed `a40_matched_score.json`); joint-epoch fidelity **90/90 folds** (== training's `primary_checkpoint.epoch`); paper parity **6/6**.
- **4-agent independent audit:** from-scratch re-derivation **bit-identical to 4 dp**; AL tail-risk, Istanbul/FL margin, and completeness all CONFIRMED.
- **Fable advisor review:** YELLOW → all rounding/wording nits fixed → clean.

## Files

New: `docs/studies/closing_data_v2/{README,TASKS,JOINT_BEST_RESULTS,PROVENANCE,AUDIT}.md`, `data/j1_results.json`, `score_all.py` (self-contained reproducer). Pointer edits: `J1_JOINT_SCORE_RUNBOOK.md` (EXECUTED banner), `JOINT_BEST_SCORING.md` (§6 Results), `v17_completion/README.md` (J1 done).

## Scope discipline

Everything is **v17 on `check2hgi_dk_ovl`** — the exact Table-3 configuration; same rundirs, same n=20 best-vs-best ceilings (`CEILINGS_N20_FINAL.md`). Nothing reported on a different version, substrate, or ceiling set. This is the camera-ready / response-letter lane — it does **not** change the submission (Table 3 stays diag-best per the author's 2026-07-09 decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2vVbCTf3XJ7qAFfwiE35N