### PR TITLE
A1 complete: CA/TX v17 MTL n=20 → v17 board complete + M1-full + T6 joint-best

### DIFF
--- a/docs/results/closing_data/catx_v17_n20/california_s1.json
+++ b/docs/results/closing_data/catx_v17_n20/california_s1.json
@@ -1,0 +1,39 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/california/mtlnet_lr1.0e-04_bs8192_ep50_20260710_030050_1345932",
+  "seed": 1,
+  "tag": "a1_california_s1",
+  "method": "reg full=top10_acc_indist*(1-ood_frac) at indist-best epoch; cat=macro-f1 at f1-best epoch; per-task diagnostic-best, fold-mean",
+  "cat_macro_f1_mean": 77.0564,
+  "cat_macro_f1_std": 0.1022,
+  "cat_per_fold": [
+    76.9315,
+    77.1527,
+    76.97,
+    77.0326,
+    77.1953
+  ],
+  "cat_best_epochs": [
+    50,
+    50,
+    46,
+    47,
+    49
+  ],
+  "reg_full_top10_mean": 65.6658,
+  "reg_full_top10_std": 0.4887,
+  "reg_per_fold": [
+    65.0175,
+    65.2613,
+    66.0399,
+    65.6589,
+    66.3513
+  ],
+  "reg_best_epochs": [
+    50,
+    48,
+    49,
+    49,
+    48
+  ],
+  "n_folds": 5
+}

--- a/docs/results/closing_data/catx_v17_n20/california_s100.json
+++ b/docs/results/closing_data/catx_v17_n20/california_s100.json
@@ -1,0 +1,39 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/california/mtlnet_lr1.0e-04_bs8192_ep50_20260711_011950_1487320",
+  "seed": 100,
+  "tag": "a1_california_s100",
+  "method": "reg full=top10_acc_indist*(1-ood_frac) at indist-best epoch; cat=macro-f1 at f1-best epoch; per-task diagnostic-best, fold-mean",
+  "cat_macro_f1_mean": 77.0554,
+  "cat_macro_f1_std": 0.1741,
+  "cat_per_fold": [
+    76.7944,
+    76.9482,
+    77.1117,
+    77.3118,
+    77.1112
+  ],
+  "cat_best_epochs": [
+    50,
+    50,
+    44,
+    50,
+    48
+  ],
+  "reg_full_top10_mean": 65.7138,
+  "reg_full_top10_std": 0.4885,
+  "reg_per_fold": [
+    64.9985,
+    65.2845,
+    66.147,
+    65.9014,
+    66.2376
+  ],
+  "reg_best_epochs": [
+    49,
+    45,
+    48,
+    50,
+    49
+  ],
+  "n_folds": 5
+}

--- a/docs/results/closing_data/catx_v17_n20/california_s7.json
+++ b/docs/results/closing_data/catx_v17_n20/california_s7.json
@@ -1,0 +1,39 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/california/mtlnet_lr1.0e-04_bs8192_ep50_20260710_141000_1416725",
+  "seed": 7,
+  "tag": "a1_california_s7",
+  "method": "reg full=top10_acc_indist*(1-ood_frac) at indist-best epoch; cat=macro-f1 at f1-best epoch; per-task diagnostic-best, fold-mean",
+  "cat_macro_f1_mean": 77.054,
+  "cat_macro_f1_std": 0.0628,
+  "cat_per_fold": [
+    76.991,
+    77.0576,
+    76.9974,
+    77.1659,
+    77.0582
+  ],
+  "cat_best_epochs": [
+    50,
+    49,
+    50,
+    49,
+    49
+  ],
+  "reg_full_top10_mean": 65.6992,
+  "reg_full_top10_std": 0.3778,
+  "reg_per_fold": [
+    65.4781,
+    65.2267,
+    65.639,
+    65.7986,
+    66.3535
+  ],
+  "reg_best_epochs": [
+    48,
+    50,
+    47,
+    50,
+    48
+  ],
+  "n_folds": 5
+}

--- a/docs/results/closing_data/catx_v17_n20/joint_best/california_s0.json
+++ b/docs/results/closing_data/catx_v17_n20/joint_best/california_s0.json
@@ -1,0 +1,167 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/california/mtlnet_lr1.0e-04_bs8192_ep50_20260701_040244_1363454",
+  "seed": 0,
+  "tag": "jb_california_0",
+  "method": "joint-best: e* = argmax_e selector(e) over epochs with 0-based index >= min_best_epoch (ties -> earliest; selector geom_simple = sqrt(cat_f1 * reg_top10_acc_indist), the mtl_cv joint-checkpoint gate); report cat macro-f1(e*) and reg full top10 = top10_acc_indist(e*)*(1-ood_fraction(e*)). diag-best: per-task best epochs, ungated (a40_score_matched.py convention). Values are percent; fold-mean \u00b1 pstdev. Selection logic: src/tracking/scoring.py.",
+  "selector_name": "geom_simple",
+  "min_best_epoch": 0,
+  "cat_task": "next_category",
+  "reg_task": "next_region",
+  "joint_best": {
+    "cat_macro_f1_mean": 77.0406,
+    "cat_macro_f1_std": 0.2001,
+    "reg_full_top10_mean": 65.6876,
+    "reg_full_top10_std": 0.3014,
+    "cat_per_fold": [
+      76.9509,
+      77.2786,
+      76.7003,
+      77.1617,
+      77.1116
+    ],
+    "reg_per_fold": [
+      65.4044,
+      65.5541,
+      65.6362,
+      65.5725,
+      66.271
+    ],
+    "epochs": [
+      48,
+      48,
+      49,
+      49,
+      49
+    ],
+    "selector_per_fold": [
+      0.70961,
+      0.711893,
+      0.709672,
+      0.711521,
+      0.715066
+    ],
+    "n_folds": 5
+  },
+  "diag_best": {
+    "cat_macro_f1_mean": 77.0422,
+    "cat_macro_f1_std": 0.2011,
+    "reg_full_top10_mean": 65.694,
+    "reg_full_top10_std": 0.3032,
+    "cat_per_fold": [
+      76.9509,
+      77.2786,
+      76.7003,
+      77.1695,
+      77.1116
+    ],
+    "reg_per_fold": [
+      65.4044,
+      65.5613,
+      65.6533,
+      65.5725,
+      66.2786
+    ],
+    "cat_best_epochs": [
+      48,
+      48,
+      49,
+      50,
+      49
+    ],
+    "reg_best_epochs": [
+      48,
+      50,
+      48,
+      49,
+      48
+    ],
+    "n_folds": 5
+  },
+  "delta_joint_minus_diag": {
+    "cat": -0.0016,
+    "reg": -0.0064
+  },
+  "per_fold": [
+    {
+      "fold": 1,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 76.9509,
+        "cat_epoch": 48,
+        "reg_full_top10": 65.4044,
+        "reg_epoch": 48
+      },
+      "joint_best": {
+        "epoch": 48,
+        "selector": 0.70961,
+        "cat_f1": 76.9509,
+        "reg_full_top10": 65.4044
+      }
+    },
+    {
+      "fold": 2,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.2786,
+        "cat_epoch": 48,
+        "reg_full_top10": 65.5613,
+        "reg_epoch": 50
+      },
+      "joint_best": {
+        "epoch": 48,
+        "selector": 0.711893,
+        "cat_f1": 77.2786,
+        "reg_full_top10": 65.5541
+      }
+    },
+    {
+      "fold": 3,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 76.7003,
+        "cat_epoch": 49,
+        "reg_full_top10": 65.6533,
+        "reg_epoch": 48
+      },
+      "joint_best": {
+        "epoch": 49,
+        "selector": 0.709672,
+        "cat_f1": 76.7003,
+        "reg_full_top10": 65.6362
+      }
+    },
+    {
+      "fold": 4,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.1695,
+        "cat_epoch": 50,
+        "reg_full_top10": 65.5725,
+        "reg_epoch": 49
+      },
+      "joint_best": {
+        "epoch": 49,
+        "selector": 0.711521,
+        "cat_f1": 77.1617,
+        "reg_full_top10": 65.5725
+      }
+    },
+    {
+      "fold": 5,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.1116,
+        "cat_epoch": 49,
+        "reg_full_top10": 66.2786,
+        "reg_epoch": 48
+      },
+      "joint_best": {
+        "epoch": 49,
+        "selector": 0.715066,
+        "cat_f1": 77.1116,
+        "reg_full_top10": 66.271
+      }
+    }
+  ],
+  "warnings": []
+}

--- a/docs/results/closing_data/catx_v17_n20/joint_best/california_s1.json
+++ b/docs/results/closing_data/catx_v17_n20/joint_best/california_s1.json
@@ -1,0 +1,167 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/california/mtlnet_lr1.0e-04_bs8192_ep50_20260710_030050_1345932",
+  "seed": 1,
+  "tag": "jb_california_1",
+  "method": "joint-best: e* = argmax_e selector(e) over epochs with 0-based index >= min_best_epoch (ties -> earliest; selector geom_simple = sqrt(cat_f1 * reg_top10_acc_indist), the mtl_cv joint-checkpoint gate); report cat macro-f1(e*) and reg full top10 = top10_acc_indist(e*)*(1-ood_fraction(e*)). diag-best: per-task best epochs, ungated (a40_score_matched.py convention). Values are percent; fold-mean \u00b1 pstdev. Selection logic: src/tracking/scoring.py.",
+  "selector_name": "geom_simple",
+  "min_best_epoch": 0,
+  "cat_task": "next_category",
+  "reg_task": "next_region",
+  "joint_best": {
+    "cat_macro_f1_mean": 77.0503,
+    "cat_macro_f1_std": 0.108,
+    "reg_full_top10_mean": 65.6617,
+    "reg_full_top10_std": 0.4882,
+    "cat_per_fold": [
+      76.9315,
+      77.1527,
+      76.9393,
+      77.0326,
+      77.1953
+    ],
+    "reg_per_fold": [
+      65.0175,
+      65.2526,
+      66.0399,
+      65.6539,
+      66.3447
+    ],
+    "epochs": [
+      50,
+      50,
+      49,
+      47,
+      49
+    ],
+    "selector_per_fold": [
+      0.707446,
+      0.709677,
+      0.712939,
+      0.711299,
+      0.715941
+    ],
+    "n_folds": 5
+  },
+  "diag_best": {
+    "cat_macro_f1_mean": 77.0564,
+    "cat_macro_f1_std": 0.1022,
+    "reg_full_top10_mean": 65.6658,
+    "reg_full_top10_std": 0.4887,
+    "cat_per_fold": [
+      76.9315,
+      77.1527,
+      76.97,
+      77.0326,
+      77.1953
+    ],
+    "reg_per_fold": [
+      65.0175,
+      65.2613,
+      66.0399,
+      65.6589,
+      66.3513
+    ],
+    "cat_best_epochs": [
+      50,
+      50,
+      46,
+      47,
+      49
+    ],
+    "reg_best_epochs": [
+      50,
+      48,
+      49,
+      49,
+      48
+    ],
+    "n_folds": 5
+  },
+  "delta_joint_minus_diag": {
+    "cat": -0.0061,
+    "reg": -0.0041
+  },
+  "per_fold": [
+    {
+      "fold": 1,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 76.9315,
+        "cat_epoch": 50,
+        "reg_full_top10": 65.0175,
+        "reg_epoch": 50
+      },
+      "joint_best": {
+        "epoch": 50,
+        "selector": 0.707446,
+        "cat_f1": 76.9315,
+        "reg_full_top10": 65.0175
+      }
+    },
+    {
+      "fold": 2,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.1527,
+        "cat_epoch": 50,
+        "reg_full_top10": 65.2613,
+        "reg_epoch": 48
+      },
+      "joint_best": {
+        "epoch": 50,
+        "selector": 0.709677,
+        "cat_f1": 77.1527,
+        "reg_full_top10": 65.2526
+      }
+    },
+    {
+      "fold": 3,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 76.97,
+        "cat_epoch": 46,
+        "reg_full_top10": 66.0399,
+        "reg_epoch": 49
+      },
+      "joint_best": {
+        "epoch": 49,
+        "selector": 0.712939,
+        "cat_f1": 76.9393,
+        "reg_full_top10": 66.0399
+      }
+    },
+    {
+      "fold": 4,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.0326,
+        "cat_epoch": 47,
+        "reg_full_top10": 65.6589,
+        "reg_epoch": 49
+      },
+      "joint_best": {
+        "epoch": 47,
+        "selector": 0.711299,
+        "cat_f1": 77.0326,
+        "reg_full_top10": 65.6539
+      }
+    },
+    {
+      "fold": 5,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.1953,
+        "cat_epoch": 49,
+        "reg_full_top10": 66.3513,
+        "reg_epoch": 48
+      },
+      "joint_best": {
+        "epoch": 49,
+        "selector": 0.715941,
+        "cat_f1": 77.1953,
+        "reg_full_top10": 66.3447
+      }
+    }
+  ],
+  "warnings": []
+}

--- a/docs/results/closing_data/catx_v17_n20/joint_best/california_s100.json
+++ b/docs/results/closing_data/catx_v17_n20/joint_best/california_s100.json
@@ -1,0 +1,167 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/california/mtlnet_lr1.0e-04_bs8192_ep50_20260711_011950_1487320",
+  "seed": 100,
+  "tag": "jb_california_100",
+  "method": "joint-best: e* = argmax_e selector(e) over epochs with 0-based index >= min_best_epoch (ties -> earliest; selector geom_simple = sqrt(cat_f1 * reg_top10_acc_indist), the mtl_cv joint-checkpoint gate); report cat macro-f1(e*) and reg full top10 = top10_acc_indist(e*)*(1-ood_fraction(e*)). diag-best: per-task best epochs, ungated (a40_score_matched.py convention). Values are percent; fold-mean \u00b1 pstdev. Selection logic: src/tracking/scoring.py.",
+  "selector_name": "geom_simple",
+  "min_best_epoch": 0,
+  "cat_task": "next_category",
+  "reg_task": "next_region",
+  "joint_best": {
+    "cat_macro_f1_mean": 77.0428,
+    "cat_macro_f1_std": 0.171,
+    "reg_full_top10_mean": 65.7131,
+    "reg_full_top10_std": 0.4892,
+    "cat_per_fold": [
+      76.7944,
+      76.9482,
+      77.0628,
+      77.3118,
+      77.0966
+    ],
+    "reg_per_fold": [
+      64.9971,
+      65.2825,
+      66.147,
+      65.9014,
+      66.2376
+    ],
+    "epochs": [
+      50,
+      50,
+      48,
+      50,
+      49
+    ],
+    "selector_per_fold": [
+      0.706788,
+      0.708917,
+      0.714067,
+      0.713946,
+      0.714705
+    ],
+    "n_folds": 5
+  },
+  "diag_best": {
+    "cat_macro_f1_mean": 77.0554,
+    "cat_macro_f1_std": 0.1741,
+    "reg_full_top10_mean": 65.7138,
+    "reg_full_top10_std": 0.4885,
+    "cat_per_fold": [
+      76.7944,
+      76.9482,
+      77.1117,
+      77.3118,
+      77.1112
+    ],
+    "reg_per_fold": [
+      64.9985,
+      65.2845,
+      66.147,
+      65.9014,
+      66.2376
+    ],
+    "cat_best_epochs": [
+      50,
+      50,
+      44,
+      50,
+      48
+    ],
+    "reg_best_epochs": [
+      49,
+      45,
+      48,
+      50,
+      49
+    ],
+    "n_folds": 5
+  },
+  "delta_joint_minus_diag": {
+    "cat": -0.0127,
+    "reg": -0.0007
+  },
+  "per_fold": [
+    {
+      "fold": 1,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 76.7944,
+        "cat_epoch": 50,
+        "reg_full_top10": 64.9985,
+        "reg_epoch": 49
+      },
+      "joint_best": {
+        "epoch": 50,
+        "selector": 0.706788,
+        "cat_f1": 76.7944,
+        "reg_full_top10": 64.9971
+      }
+    },
+    {
+      "fold": 2,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 76.9482,
+        "cat_epoch": 50,
+        "reg_full_top10": 65.2845,
+        "reg_epoch": 45
+      },
+      "joint_best": {
+        "epoch": 50,
+        "selector": 0.708917,
+        "cat_f1": 76.9482,
+        "reg_full_top10": 65.2825
+      }
+    },
+    {
+      "fold": 3,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.1117,
+        "cat_epoch": 44,
+        "reg_full_top10": 66.147,
+        "reg_epoch": 48
+      },
+      "joint_best": {
+        "epoch": 48,
+        "selector": 0.714067,
+        "cat_f1": 77.0628,
+        "reg_full_top10": 66.147
+      }
+    },
+    {
+      "fold": 4,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.3118,
+        "cat_epoch": 50,
+        "reg_full_top10": 65.9014,
+        "reg_epoch": 50
+      },
+      "joint_best": {
+        "epoch": 50,
+        "selector": 0.713946,
+        "cat_f1": 77.3118,
+        "reg_full_top10": 65.9014
+      }
+    },
+    {
+      "fold": 5,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.1112,
+        "cat_epoch": 48,
+        "reg_full_top10": 66.2376,
+        "reg_epoch": 49
+      },
+      "joint_best": {
+        "epoch": 49,
+        "selector": 0.714705,
+        "cat_f1": 77.0966,
+        "reg_full_top10": 66.2376
+      }
+    }
+  ],
+  "warnings": []
+}

--- a/docs/results/closing_data/catx_v17_n20/joint_best/california_s7.json
+++ b/docs/results/closing_data/catx_v17_n20/joint_best/california_s7.json
@@ -1,0 +1,167 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/california/mtlnet_lr1.0e-04_bs8192_ep50_20260710_141000_1416725",
+  "seed": 7,
+  "tag": "jb_california_7",
+  "method": "joint-best: e* = argmax_e selector(e) over epochs with 0-based index >= min_best_epoch (ties -> earliest; selector geom_simple = sqrt(cat_f1 * reg_top10_acc_indist), the mtl_cv joint-checkpoint gate); report cat macro-f1(e*) and reg full top10 = top10_acc_indist(e*)*(1-ood_fraction(e*)). diag-best: per-task best epochs, ungated (a40_score_matched.py convention). Values are percent; fold-mean \u00b1 pstdev. Selection logic: src/tracking/scoring.py.",
+  "selector_name": "geom_simple",
+  "min_best_epoch": 0,
+  "cat_task": "next_category",
+  "reg_task": "next_region",
+  "joint_best": {
+    "cat_macro_f1_mean": 77.0522,
+    "cat_macro_f1_std": 0.0645,
+    "reg_full_top10_mean": 65.6974,
+    "reg_full_top10_std": 0.3758,
+    "cat_per_fold": [
+      76.9862,
+      77.0576,
+      76.9933,
+      77.1659,
+      77.0582
+    ],
+    "reg_per_fold": [
+      65.4781,
+      65.2263,
+      65.6387,
+      65.796,
+      66.3477
+    ],
+    "epochs": [
+      48,
+      49,
+      48,
+      49,
+      49
+    ],
+    "selector_per_fold": [
+      0.710164,
+      0.709184,
+      0.711114,
+      0.712781,
+      0.715139
+    ],
+    "n_folds": 5
+  },
+  "diag_best": {
+    "cat_macro_f1_mean": 77.054,
+    "cat_macro_f1_std": 0.0628,
+    "reg_full_top10_mean": 65.6992,
+    "reg_full_top10_std": 0.3778,
+    "cat_per_fold": [
+      76.991,
+      77.0576,
+      76.9974,
+      77.1659,
+      77.0582
+    ],
+    "reg_per_fold": [
+      65.4781,
+      65.2267,
+      65.639,
+      65.7986,
+      66.3535
+    ],
+    "cat_best_epochs": [
+      50,
+      49,
+      50,
+      49,
+      49
+    ],
+    "reg_best_epochs": [
+      48,
+      50,
+      47,
+      50,
+      48
+    ],
+    "n_folds": 5
+  },
+  "delta_joint_minus_diag": {
+    "cat": -0.0018,
+    "reg": -0.0018
+  },
+  "per_fold": [
+    {
+      "fold": 1,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 76.991,
+        "cat_epoch": 50,
+        "reg_full_top10": 65.4781,
+        "reg_epoch": 48
+      },
+      "joint_best": {
+        "epoch": 48,
+        "selector": 0.710164,
+        "cat_f1": 76.9862,
+        "reg_full_top10": 65.4781
+      }
+    },
+    {
+      "fold": 2,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.0576,
+        "cat_epoch": 49,
+        "reg_full_top10": 65.2267,
+        "reg_epoch": 50
+      },
+      "joint_best": {
+        "epoch": 49,
+        "selector": 0.709184,
+        "cat_f1": 77.0576,
+        "reg_full_top10": 65.2263
+      }
+    },
+    {
+      "fold": 3,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 76.9974,
+        "cat_epoch": 50,
+        "reg_full_top10": 65.639,
+        "reg_epoch": 47
+      },
+      "joint_best": {
+        "epoch": 48,
+        "selector": 0.711114,
+        "cat_f1": 76.9933,
+        "reg_full_top10": 65.6387
+      }
+    },
+    {
+      "fold": 4,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.1659,
+        "cat_epoch": 49,
+        "reg_full_top10": 65.7986,
+        "reg_epoch": 50
+      },
+      "joint_best": {
+        "epoch": 49,
+        "selector": 0.712781,
+        "cat_f1": 77.1659,
+        "reg_full_top10": 65.796
+      }
+    },
+    {
+      "fold": 5,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.0582,
+        "cat_epoch": 49,
+        "reg_full_top10": 66.3535,
+        "reg_epoch": 48
+      },
+      "joint_best": {
+        "epoch": 49,
+        "selector": 0.715139,
+        "cat_f1": 77.0582,
+        "reg_full_top10": 66.3477
+      }
+    }
+  ],
+  "warnings": []
+}

--- a/docs/results/closing_data/catx_v17_n20/joint_best/texas_s0.json
+++ b/docs/results/closing_data/catx_v17_n20/joint_best/texas_s0.json
@@ -1,0 +1,167 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/texas/mtlnet_lr1.0e-04_bs8192_ep50_20260701_085836_1419069",
+  "seed": 0,
+  "tag": "jb_texas_0",
+  "method": "joint-best: e* = argmax_e selector(e) over epochs with 0-based index >= min_best_epoch (ties -> earliest; selector geom_simple = sqrt(cat_f1 * reg_top10_acc_indist), the mtl_cv joint-checkpoint gate); report cat macro-f1(e*) and reg full top10 = top10_acc_indist(e*)*(1-ood_fraction(e*)). diag-best: per-task best epochs, ungated (a40_score_matched.py convention). Values are percent; fold-mean \u00b1 pstdev. Selection logic: src/tracking/scoring.py.",
+  "selector_name": "geom_simple",
+  "min_best_epoch": 0,
+  "cat_task": "next_category",
+  "reg_task": "next_region",
+  "joint_best": {
+    "cat_macro_f1_mean": 77.227,
+    "cat_macro_f1_std": 0.1237,
+    "reg_full_top10_mean": 67.0711,
+    "reg_full_top10_std": 0.4491,
+    "cat_per_fold": [
+      77.4234,
+      77.0575,
+      77.1903,
+      77.2942,
+      77.1695
+    ],
+    "reg_per_fold": [
+      66.9747,
+      67.3614,
+      66.2423,
+      67.2732,
+      67.5038
+    ],
+    "epochs": [
+      49,
+      50,
+      49,
+      49,
+      50
+    ],
+    "selector_per_fold": [
+      0.720151,
+      0.720535,
+      0.715108,
+      0.721131,
+      0.721819
+    ],
+    "n_folds": 5
+  },
+  "diag_best": {
+    "cat_macro_f1_mean": 77.2272,
+    "cat_macro_f1_std": 0.1236,
+    "reg_full_top10_mean": 67.0723,
+    "reg_full_top10_std": 0.449,
+    "cat_per_fold": [
+      77.4234,
+      77.0575,
+      77.1915,
+      77.2942,
+      77.1695
+    ],
+    "reg_per_fold": [
+      66.9797,
+      67.3614,
+      66.2423,
+      67.2743,
+      67.5038
+    ],
+    "cat_best_epochs": [
+      49,
+      50,
+      50,
+      49,
+      50
+    ],
+    "reg_best_epochs": [
+      50,
+      50,
+      49,
+      50,
+      50
+    ],
+    "n_folds": 5
+  },
+  "delta_joint_minus_diag": {
+    "cat": -0.0002,
+    "reg": -0.0012
+  },
+  "per_fold": [
+    {
+      "fold": 1,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.4234,
+        "cat_epoch": 49,
+        "reg_full_top10": 66.9797,
+        "reg_epoch": 50
+      },
+      "joint_best": {
+        "epoch": 49,
+        "selector": 0.720151,
+        "cat_f1": 77.4234,
+        "reg_full_top10": 66.9747
+      }
+    },
+    {
+      "fold": 2,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.0575,
+        "cat_epoch": 50,
+        "reg_full_top10": 67.3614,
+        "reg_epoch": 50
+      },
+      "joint_best": {
+        "epoch": 50,
+        "selector": 0.720535,
+        "cat_f1": 77.0575,
+        "reg_full_top10": 67.3614
+      }
+    },
+    {
+      "fold": 3,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.1915,
+        "cat_epoch": 50,
+        "reg_full_top10": 66.2423,
+        "reg_epoch": 49
+      },
+      "joint_best": {
+        "epoch": 49,
+        "selector": 0.715108,
+        "cat_f1": 77.1903,
+        "reg_full_top10": 66.2423
+      }
+    },
+    {
+      "fold": 4,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.2942,
+        "cat_epoch": 49,
+        "reg_full_top10": 67.2743,
+        "reg_epoch": 50
+      },
+      "joint_best": {
+        "epoch": 49,
+        "selector": 0.721131,
+        "cat_f1": 77.2942,
+        "reg_full_top10": 67.2732
+      }
+    },
+    {
+      "fold": 5,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.1695,
+        "cat_epoch": 50,
+        "reg_full_top10": 67.5038,
+        "reg_epoch": 50
+      },
+      "joint_best": {
+        "epoch": 50,
+        "selector": 0.721819,
+        "cat_f1": 77.1695,
+        "reg_full_top10": 67.5038
+      }
+    }
+  ],
+  "warnings": []
+}

--- a/docs/results/closing_data/catx_v17_n20/joint_best/texas_s1.json
+++ b/docs/results/closing_data/catx_v17_n20/joint_best/texas_s1.json
@@ -1,0 +1,167 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/texas/mtlnet_lr1.0e-04_bs8192_ep50_20260710_075308_1375703",
+  "seed": 1,
+  "tag": "jb_texas_1",
+  "method": "joint-best: e* = argmax_e selector(e) over epochs with 0-based index >= min_best_epoch (ties -> earliest; selector geom_simple = sqrt(cat_f1 * reg_top10_acc_indist), the mtl_cv joint-checkpoint gate); report cat macro-f1(e*) and reg full top10 = top10_acc_indist(e*)*(1-ood_fraction(e*)). diag-best: per-task best epochs, ungated (a40_score_matched.py convention). Values are percent; fold-mean \u00b1 pstdev. Selection logic: src/tracking/scoring.py.",
+  "selector_name": "geom_simple",
+  "min_best_epoch": 0,
+  "cat_task": "next_category",
+  "reg_task": "next_region",
+  "joint_best": {
+    "cat_macro_f1_mean": 77.2265,
+    "cat_macro_f1_std": 0.1418,
+    "reg_full_top10_mean": 67.0561,
+    "reg_full_top10_std": 0.5818,
+    "cat_per_fold": [
+      77.4203,
+      77.1582,
+      77.0072,
+      77.3271,
+      77.22
+    ],
+    "reg_per_fold": [
+      66.8604,
+      67.1139,
+      66.0565,
+      67.5754,
+      67.6742
+    ],
+    "epochs": [
+      49,
+      50,
+      50,
+      50,
+      50
+    ],
+    "selector_per_fold": [
+      0.719523,
+      0.719644,
+      0.713272,
+      0.722901,
+      0.722969
+    ],
+    "n_folds": 5
+  },
+  "diag_best": {
+    "cat_macro_f1_mean": 77.2265,
+    "cat_macro_f1_std": 0.1418,
+    "reg_full_top10_mean": 67.0617,
+    "reg_full_top10_std": 0.5836,
+    "cat_per_fold": [
+      77.4203,
+      77.1582,
+      77.0072,
+      77.3271,
+      77.22
+    ],
+    "reg_per_fold": [
+      66.8606,
+      67.1173,
+      66.0626,
+      67.577,
+      67.6908
+    ],
+    "cat_best_epochs": [
+      49,
+      50,
+      50,
+      50,
+      50
+    ],
+    "reg_best_epochs": [
+      50,
+      45,
+      47,
+      48,
+      47
+    ],
+    "n_folds": 5
+  },
+  "delta_joint_minus_diag": {
+    "cat": 0.0,
+    "reg": -0.0056
+  },
+  "per_fold": [
+    {
+      "fold": 1,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.4203,
+        "cat_epoch": 49,
+        "reg_full_top10": 66.8606,
+        "reg_epoch": 50
+      },
+      "joint_best": {
+        "epoch": 49,
+        "selector": 0.719523,
+        "cat_f1": 77.4203,
+        "reg_full_top10": 66.8604
+      }
+    },
+    {
+      "fold": 2,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.1582,
+        "cat_epoch": 50,
+        "reg_full_top10": 67.1173,
+        "reg_epoch": 45
+      },
+      "joint_best": {
+        "epoch": 50,
+        "selector": 0.719644,
+        "cat_f1": 77.1582,
+        "reg_full_top10": 67.1139
+      }
+    },
+    {
+      "fold": 3,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.0072,
+        "cat_epoch": 50,
+        "reg_full_top10": 66.0626,
+        "reg_epoch": 47
+      },
+      "joint_best": {
+        "epoch": 50,
+        "selector": 0.713272,
+        "cat_f1": 77.0072,
+        "reg_full_top10": 66.0565
+      }
+    },
+    {
+      "fold": 4,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.3271,
+        "cat_epoch": 50,
+        "reg_full_top10": 67.577,
+        "reg_epoch": 48
+      },
+      "joint_best": {
+        "epoch": 50,
+        "selector": 0.722901,
+        "cat_f1": 77.3271,
+        "reg_full_top10": 67.5754
+      }
+    },
+    {
+      "fold": 5,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.22,
+        "cat_epoch": 50,
+        "reg_full_top10": 67.6908,
+        "reg_epoch": 47
+      },
+      "joint_best": {
+        "epoch": 50,
+        "selector": 0.722969,
+        "cat_f1": 77.22,
+        "reg_full_top10": 67.6742
+      }
+    }
+  ],
+  "warnings": []
+}

--- a/docs/results/closing_data/catx_v17_n20/joint_best/texas_s100.json
+++ b/docs/results/closing_data/catx_v17_n20/joint_best/texas_s100.json
@@ -1,0 +1,167 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/texas/mtlnet_lr1.0e-04_bs8192_ep50_20260711_061331_1517315",
+  "seed": 100,
+  "tag": "jb_texas_100",
+  "method": "joint-best: e* = argmax_e selector(e) over epochs with 0-based index >= min_best_epoch (ties -> earliest; selector geom_simple = sqrt(cat_f1 * reg_top10_acc_indist), the mtl_cv joint-checkpoint gate); report cat macro-f1(e*) and reg full top10 = top10_acc_indist(e*)*(1-ood_fraction(e*)). diag-best: per-task best epochs, ungated (a40_score_matched.py convention). Values are percent; fold-mean \u00b1 pstdev. Selection logic: src/tracking/scoring.py.",
+  "selector_name": "geom_simple",
+  "min_best_epoch": 0,
+  "cat_task": "next_category",
+  "reg_task": "next_region",
+  "joint_best": {
+    "cat_macro_f1_mean": 77.2424,
+    "cat_macro_f1_std": 0.1647,
+    "reg_full_top10_mean": 67.0599,
+    "reg_full_top10_std": 0.5354,
+    "cat_per_fold": [
+      77.3372,
+      77.3743,
+      77.0761,
+      77.4117,
+      77.0125
+    ],
+    "reg_per_fold": [
+      66.6488,
+      67.626,
+      66.2185,
+      67.3887,
+      67.4176
+    ],
+    "epochs": [
+      48,
+      49,
+      48,
+      50,
+      50
+    ],
+    "selector_per_fold": [
+      0.717998,
+      0.723422,
+      0.714463,
+      0.722307,
+      0.720599
+    ],
+    "n_folds": 5
+  },
+  "diag_best": {
+    "cat_macro_f1_mean": 77.2424,
+    "cat_macro_f1_std": 0.1647,
+    "reg_full_top10_mean": 67.0623,
+    "reg_full_top10_std": 0.5361,
+    "cat_per_fold": [
+      77.3372,
+      77.3743,
+      77.0761,
+      77.4117,
+      77.0125
+    ],
+    "reg_per_fold": [
+      66.6539,
+      67.6328,
+      66.2185,
+      67.3887,
+      67.4176
+    ],
+    "cat_best_epochs": [
+      48,
+      49,
+      48,
+      50,
+      50
+    ],
+    "reg_best_epochs": [
+      49,
+      48,
+      48,
+      50,
+      50
+    ],
+    "n_folds": 5
+  },
+  "delta_joint_minus_diag": {
+    "cat": 0.0,
+    "reg": -0.0024
+  },
+  "per_fold": [
+    {
+      "fold": 1,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.3372,
+        "cat_epoch": 48,
+        "reg_full_top10": 66.6539,
+        "reg_epoch": 49
+      },
+      "joint_best": {
+        "epoch": 48,
+        "selector": 0.717998,
+        "cat_f1": 77.3372,
+        "reg_full_top10": 66.6488
+      }
+    },
+    {
+      "fold": 2,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.3743,
+        "cat_epoch": 49,
+        "reg_full_top10": 67.6328,
+        "reg_epoch": 48
+      },
+      "joint_best": {
+        "epoch": 49,
+        "selector": 0.723422,
+        "cat_f1": 77.3743,
+        "reg_full_top10": 67.626
+      }
+    },
+    {
+      "fold": 3,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.0761,
+        "cat_epoch": 48,
+        "reg_full_top10": 66.2185,
+        "reg_epoch": 48
+      },
+      "joint_best": {
+        "epoch": 48,
+        "selector": 0.714463,
+        "cat_f1": 77.0761,
+        "reg_full_top10": 66.2185
+      }
+    },
+    {
+      "fold": 4,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.4117,
+        "cat_epoch": 50,
+        "reg_full_top10": 67.3887,
+        "reg_epoch": 50
+      },
+      "joint_best": {
+        "epoch": 50,
+        "selector": 0.722307,
+        "cat_f1": 77.4117,
+        "reg_full_top10": 67.3887
+      }
+    },
+    {
+      "fold": 5,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.0125,
+        "cat_epoch": 50,
+        "reg_full_top10": 67.4176,
+        "reg_epoch": 50
+      },
+      "joint_best": {
+        "epoch": 50,
+        "selector": 0.720599,
+        "cat_f1": 77.0125,
+        "reg_full_top10": 67.4176
+      }
+    }
+  ],
+  "warnings": []
+}

--- a/docs/results/closing_data/catx_v17_n20/joint_best/texas_s7.json
+++ b/docs/results/closing_data/catx_v17_n20/joint_best/texas_s7.json
@@ -1,0 +1,167 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/texas/mtlnet_lr1.0e-04_bs8192_ep50_20260710_190309_1446702",
+  "seed": 7,
+  "tag": "jb_texas_7",
+  "method": "joint-best: e* = argmax_e selector(e) over epochs with 0-based index >= min_best_epoch (ties -> earliest; selector geom_simple = sqrt(cat_f1 * reg_top10_acc_indist), the mtl_cv joint-checkpoint gate); report cat macro-f1(e*) and reg full top10 = top10_acc_indist(e*)*(1-ood_fraction(e*)). diag-best: per-task best epochs, ungated (a40_score_matched.py convention). Values are percent; fold-mean \u00b1 pstdev. Selection logic: src/tracking/scoring.py.",
+  "selector_name": "geom_simple",
+  "min_best_epoch": 0,
+  "cat_task": "next_category",
+  "reg_task": "next_region",
+  "joint_best": {
+    "cat_macro_f1_mean": 77.2584,
+    "cat_macro_f1_std": 0.0419,
+    "reg_full_top10_mean": 67.0488,
+    "reg_full_top10_std": 0.3623,
+    "cat_per_fold": [
+      77.3105,
+      77.2262,
+      77.2918,
+      77.2667,
+      77.1964
+    ],
+    "reg_per_fold": [
+      66.9036,
+      67.3331,
+      66.4292,
+      67.1231,
+      67.4548
+    ],
+    "epochs": [
+      48,
+      49,
+      48,
+      50,
+      47
+    ],
+    "selector_per_fold": [
+      0.719233,
+      0.721182,
+      0.716593,
+      0.72021,
+      0.721666
+    ],
+    "n_folds": 5
+  },
+  "diag_best": {
+    "cat_macro_f1_mean": 77.26,
+    "cat_macro_f1_std": 0.0433,
+    "reg_full_top10_mean": 67.0512,
+    "reg_full_top10_std": 0.363,
+    "cat_per_fold": [
+      77.3105,
+      77.2262,
+      77.3001,
+      77.2667,
+      77.1964
+    ],
+    "reg_per_fold": [
+      66.904,
+      67.3331,
+      66.4313,
+      67.1273,
+      67.4604
+    ],
+    "cat_best_epochs": [
+      48,
+      49,
+      50,
+      50,
+      47
+    ],
+    "reg_best_epochs": [
+      50,
+      49,
+      47,
+      47,
+      49
+    ],
+    "n_folds": 5
+  },
+  "delta_joint_minus_diag": {
+    "cat": -0.0017,
+    "reg": -0.0025
+  },
+  "per_fold": [
+    {
+      "fold": 1,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.3105,
+        "cat_epoch": 48,
+        "reg_full_top10": 66.904,
+        "reg_epoch": 50
+      },
+      "joint_best": {
+        "epoch": 48,
+        "selector": 0.719233,
+        "cat_f1": 77.3105,
+        "reg_full_top10": 66.9036
+      }
+    },
+    {
+      "fold": 2,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.2262,
+        "cat_epoch": 49,
+        "reg_full_top10": 67.3331,
+        "reg_epoch": 49
+      },
+      "joint_best": {
+        "epoch": 49,
+        "selector": 0.721182,
+        "cat_f1": 77.2262,
+        "reg_full_top10": 67.3331
+      }
+    },
+    {
+      "fold": 3,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.3001,
+        "cat_epoch": 50,
+        "reg_full_top10": 66.4313,
+        "reg_epoch": 47
+      },
+      "joint_best": {
+        "epoch": 48,
+        "selector": 0.716593,
+        "cat_f1": 77.2918,
+        "reg_full_top10": 66.4292
+      }
+    },
+    {
+      "fold": 4,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.2667,
+        "cat_epoch": 50,
+        "reg_full_top10": 67.1273,
+        "reg_epoch": 47
+      },
+      "joint_best": {
+        "epoch": 50,
+        "selector": 0.72021,
+        "cat_f1": 77.2667,
+        "reg_full_top10": 67.1231
+      }
+    },
+    {
+      "fold": 5,
+      "source": "csv",
+      "diag_best": {
+        "cat_f1": 77.1964,
+        "cat_epoch": 47,
+        "reg_full_top10": 67.4604,
+        "reg_epoch": 49
+      },
+      "joint_best": {
+        "epoch": 47,
+        "selector": 0.721666,
+        "cat_f1": 77.1964,
+        "reg_full_top10": 67.4548
+      }
+    }
+  ],
+  "warnings": []
+}

--- a/docs/results/closing_data/catx_v17_n20/texas_s1.json
+++ b/docs/results/closing_data/catx_v17_n20/texas_s1.json
@@ -1,0 +1,39 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/texas/mtlnet_lr1.0e-04_bs8192_ep50_20260710_075308_1375703",
+  "seed": 1,
+  "tag": "a1_texas_s1",
+  "method": "reg full=top10_acc_indist*(1-ood_frac) at indist-best epoch; cat=macro-f1 at f1-best epoch; per-task diagnostic-best, fold-mean",
+  "cat_macro_f1_mean": 77.2265,
+  "cat_macro_f1_std": 0.1418,
+  "cat_per_fold": [
+    77.4203,
+    77.1582,
+    77.0072,
+    77.3271,
+    77.22
+  ],
+  "cat_best_epochs": [
+    49,
+    50,
+    50,
+    50,
+    50
+  ],
+  "reg_full_top10_mean": 67.0617,
+  "reg_full_top10_std": 0.5836,
+  "reg_per_fold": [
+    66.8606,
+    67.1173,
+    66.0626,
+    67.577,
+    67.6908
+  ],
+  "reg_best_epochs": [
+    50,
+    45,
+    47,
+    48,
+    47
+  ],
+  "n_folds": 5
+}

--- a/docs/results/closing_data/catx_v17_n20/texas_s100.json
+++ b/docs/results/closing_data/catx_v17_n20/texas_s100.json
@@ -1,0 +1,39 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/texas/mtlnet_lr1.0e-04_bs8192_ep50_20260711_061331_1517315",
+  "seed": 100,
+  "tag": "a1_texas_s100",
+  "method": "reg full=top10_acc_indist*(1-ood_frac) at indist-best epoch; cat=macro-f1 at f1-best epoch; per-task diagnostic-best, fold-mean",
+  "cat_macro_f1_mean": 77.2424,
+  "cat_macro_f1_std": 0.1647,
+  "cat_per_fold": [
+    77.3372,
+    77.3743,
+    77.0761,
+    77.4117,
+    77.0125
+  ],
+  "cat_best_epochs": [
+    48,
+    49,
+    48,
+    50,
+    50
+  ],
+  "reg_full_top10_mean": 67.0623,
+  "reg_full_top10_std": 0.5361,
+  "reg_per_fold": [
+    66.6539,
+    67.6328,
+    66.2185,
+    67.3887,
+    67.4176
+  ],
+  "reg_best_epochs": [
+    49,
+    48,
+    48,
+    50,
+    50
+  ],
+  "n_folds": 5
+}

--- a/docs/results/closing_data/catx_v17_n20/texas_s7.json
+++ b/docs/results/closing_data/catx_v17_n20/texas_s7.json
@@ -1,0 +1,39 @@
+{
+  "rundir": "results/check2hgi_dk_ovl/texas/mtlnet_lr1.0e-04_bs8192_ep50_20260710_190309_1446702",
+  "seed": 7,
+  "tag": "a1_texas_s7",
+  "method": "reg full=top10_acc_indist*(1-ood_frac) at indist-best epoch; cat=macro-f1 at f1-best epoch; per-task diagnostic-best, fold-mean",
+  "cat_macro_f1_mean": 77.26,
+  "cat_macro_f1_std": 0.0433,
+  "cat_per_fold": [
+    77.3105,
+    77.2262,
+    77.3001,
+    77.2667,
+    77.1964
+  ],
+  "cat_best_epochs": [
+    48,
+    49,
+    50,
+    50,
+    47
+  ],
+  "reg_full_top10_mean": 67.0512,
+  "reg_full_top10_std": 0.363,
+  "reg_per_fold": [
+    66.904,
+    67.3331,
+    66.4313,
+    67.1273,
+    67.4604
+  ],
+  "reg_best_epochs": [
+    50,
+    49,
+    47,
+    47,
+    49
+  ],
+  "n_folds": 5
+}

--- a/docs/studies/closing_data/JOINT_BEST_SCORING.md
+++ b/docs/studies/closing_data/JOINT_BEST_SCORING.md
@@ -57,7 +57,8 @@ Rundir families to cover (see [`v17_completion/README.md`](v17_completion/README
 
 - **perhead_lr_n20** — AL / AZ / FL, n=20 {0,1,7,100}×5f (`perhead_lr_n20.md`; driver `run_n20_perhead.sh`,
   per-PID rundirs — see `train_perf_multifold/BATCH_SIZE_SWEEP.md` for the rundir→seed mapping caveat).
-- **catx_v17_seed0_5f** — CA / TX seed-0 5f (`catx_v17_seed0_5f/RESULTS.md`) + the CA/TX n=20 rundirs once A1 lands.
+- **catx_v17_seed0_5f** — CA / TX seed-0 5f (`catx_v17_seed0_5f/RESULTS.md`) + the CA/TX n=20 rundirs (A1 done
+  2026-07-11 on the A40 — `docs/results/closing_data/catx_v17_n20/`; the n=20 *joint-best* re-score is the still-pending CPU task T6).
 - **h3_istanbul** — Istanbul dk_ovl+v17 n=20 (`v17_completion/h3_istanbul/RESULTS.md`, `step3_runs`).
 
 Legacy rundirs (pre-fix) have no `standard_scores.json`; the scorer falls back to the CSVs automatically.

--- a/docs/studies/closing_data/RESULTS_BOARD.md
+++ b/docs/studies/closing_data/RESULTS_BOARD.md
@@ -27,15 +27,18 @@
 > | AL (1109) | **64.54** | 63.56 | **+0.99** | 69.80 | ≈ | n=20 `perhead_lr_n20.md` |
 > | AZ (1547) | **65.84** | 63.39 | **+2.45** | 59.56 | ≈ | n=20 `perhead_lr_n20.md` |
 > | FL (4703) | **79.85** | 79.68 (n=20 base) | **+0.17** | 77.42 | **+0.20** | n=20 `perhead_lr_n20.md` |
-> | CA (8501) | 77.04±0.20 | 77.33 (bf16 board) | **−0.29** | 65.69±0.30 | **+0.03** | s0-5f `catx_v17_seed0_5f/RESULTS.md` |
-> | TX (6553) | 77.23±0.12 | 77.51 (**fp32** board) | **−0.28** | 67.07±0.45 | **+0.05** | s0-5f `catx_v17_seed0_5f/RESULTS.md` |
+> | CA (8501) | 77.05±0.01 | 77.33 (bf16 board) | **−0.28** | 65.69±0.02 | **+0.03** | **n=20** `catx_v17_n20/` |
+> | TX (6553) | 77.24±0.01 | 77.51 (**fp32** board) | **−0.27** | 67.06±0.01 | **+0.04** | **n=20** `catx_v17_n20/` |
 >
 > **Honest read:** v17's cat lever **wins at small/mid states (+0.2…+2.5)** but **costs ~0.28 pp cat at the two
 > largest states (CA/TX)**, while **reg ties/beats everywhere**. The large-state dip is **real, not a bf16 artifact**
-> — TX's board is fp32 (clean same-precision) and still −0.28 (~2σ), matching CA's −0.29. §1 below stays the **board
-> of record** (n=5 seed-0) until CA/TX land at **n=20 on the A40** ({1,7,100}; the H100 lane is gone — see
-> `v17_completion/A40.md`), which firms the large-state Δcat significance. v17 remains `DEFAULT_CANON`;
-> §1 headline updates after the CA/TX n=20 + the flag-OFF parity test.
+> — TX's board is fp32 (clean same-precision) and still −0.27 (~2σ), matching CA's −0.28. ✅ **CA/TX landed at n=20 on
+> the A40** (A1, {1,7,100}, complete **2026-07-11** — `docs/results/closing_data/catx_v17_n20/`): the top-up
+> **confirms** the seed-0 values with very tight cross-seed variance (CA cat 77.052 ±0.006 / reg 65.693 ±0.017;
+> TX cat 77.239 ±0.014 / reg 67.062 ±0.007), so the large-state −0.28 cat trade and the +0.03/+0.04 reg gain are now
+> firm at n=20. **Every v17 board cell is now n=20 — the board is complete.** v17 remains `DEFAULT_CANON`.
+> (The frozen v16 §1 table below is unchanged — it is the v16 board-of-record, a separate lineage; the v17 Δs-vs-ceiling
+> live in [`v17_completion/CEILINGS_N20_FINAL.md`](v17_completion/CEILINGS_N20_FINAL.md), now n=20 at all states.)
 >
 > 📐 **Which ceiling table is which (reconciliation, 2026-07-08 — do not mix):** the Gowalla **§1 table below uses the
 > OLD ceilings** (v16-era recipe `max_lr 3e-3`, **seed-0 n=5**) against the v16 MTL — it is the frozen v16

--- a/docs/studies/closing_data/catx_v17_seed0_5f/RESULTS.md
+++ b/docs/studies/closing_data/catx_v17_seed0_5f/RESULTS.md
@@ -4,7 +4,20 @@ Champion **v17** (= v16 + bs8192 + per-head cat-lr 1e-3 via `MTL_ONECYCLE_PER_HE
 engine `check2hgi_dk_ovl` (gated stride-1 overlap), **fp32** (`MTL_DISABLE_AMP=1`), matched scorer
 `a40_score_matched.py`. Serial on the A40 (2-wide infeasible: 2×~27 GB VRAM > 46; fold-construction RAM guard).
 
-## Cells
+> ✅ **n=20 COMPLETE (A1 on the A40, 2026-07-11).** Seeds `{1,7,100}` added to seed-0 → full n=20 (4 seeds × 5 folds).
+> Per-cell scores: `docs/results/closing_data/catx_v17_n20/{california,texas}_s{1,7,100}.json`. Driver
+> `v17_completion/a1_catx/run_a1_catx_n20.sh` (1-wide fp32, RAM-gated, resumable — TX s100 auto-recovered a transient
+> rc=132 crash via the 2× retry). The n=20 **CONFIRMS** the seed-0 values below with tight cross-seed variance:
+>
+> | state | v17 cat (n=20) | v17 reg (n=20) | Δcat vs ceiling | Δreg vs ceiling |
+> |---|---|---|---|---|
+> | **CA** | **77.052 ± 0.006** | **65.693 ± 0.017** | **+6.45** ✅beats | **+2.20** ✅beats |
+> | **TX** | **77.239 ± 0.014** | **67.062 ± 0.007** | **+7.45** ✅beats | **+2.11** ✅beats |
+>
+> (Δ vs the n=20 STL ceilings in `CEILINGS_N20_FINAL.md`: CA cat 70.60/reg 63.49, TX cat 69.79/reg 64.95.) The
+> seed-0 table below is retained for provenance; **the n=20 above is the number of record.**
+
+## Cells (seed-0, original — superseded by the n=20 banner above)
 
 | state (regions) | v17 cat macro-F1 | board cat | Δcat | v17 reg top10 | board reg | Δreg | board prec |
 |---|---|---|---|---|---|---|---|
@@ -34,6 +47,8 @@ Accept the small large-state cat cost (~0.28 pp, reg-neutral) for the large smal
 simplicity. **v17 stays `DEFAULT_CANON`.** The large-state cat trade is documented here + in the board callout so
 it travels with the numbers.
 
-## Next
-Seeds **{1,7,100} → H100** (`run_catx_v17_n20_h100.sh` + `CATX_V17_N20_H100_HANDOFF.md`) to complete CA/TX at
-n=20. The H100 fp32 n=20 will firm up the large-state Δcat significance (paired vs the v16 board).
+## Next — ✅ DONE
+Seeds **{1,7,100}** completed on the **A40** (2026-07-11, A1; the H100 lane was retired) → CA/TX at **n=20**. The
+fp32 n=20 firmed the large-state Δ significance: the v17-vs-v16-board cat trade holds (CA −0.28 / TX −0.27) and
+reg ties+ (CA +0.03 / TX +0.04), now at n=20 with cross-seed σ ≤ 0.017. **The v17 board is complete** — folded into
+`CEILINGS_N20_FINAL.md`, `RESULTS_BOARD §1`, and `stats_n20/RESULTS.md` (M1-full unblocked).

--- a/docs/studies/closing_data/log.md
+++ b/docs/studies/closing_data/log.md
@@ -391,3 +391,15 @@ CA 58.52 (folds 0–1)**, fold counts disclosed wherever cited. Defensible: the 
 the missing folds can't flip the sandwich. The "STAN infeasible at CA/TX" footnote is DROPPED (n-folds disclosure
 replaces it). Remaining 4 folds = optional post-deadline robustness. Docs flipped: `stan.md` + `comparison.md`
 (cells filled), RESULTS_BOARD §4, stan_catx/STATUS.md, v17_completion README + A40 queue (~10 h freed for A1).
+
+## 2026-07-11 — A1 DONE (CA/TX v17 MTL n=20) → v17 board COMPLETE
+
+**A1 (ex-H1) finished on the A40** (the H100 lane was retired) — CA/TX v17 MTL n=20, seeds {1,7,100} × 5f, 1-wide
+fp32, resumable. 6/6 cells: **CA cat 77.052 ±0.006 / reg 65.693 ±0.017 · TX cat 77.239 ±0.014 / reg 67.062 ±0.007**
+(`docs/results/closing_data/catx_v17_n20/`). The n=20 **CONFIRMS** the seed-0 values within <0.13 pp (cross-seed
+σ ≤ 0.017) — the "MTL beats both STL ceilings at CA/TX" verdict now holds at full n=20 (Δcat +6.45/+7.45,
+Δreg +2.20/+2.11 vs the n=20 ceilings). **Every v17 board cell is now n=20 — the board is complete.** Folded into
+`CEILINGS_N20_FINAL.md`, `RESULTS_BOARD §1`, `catx_v17_seed0_5f/RESULTS.md`, `v17_completion/A40.md` (commits
+`8bf2a55`, `b766a3d`). M1-full is now unblocked at all 6 (remaining: re-run `m1_stats_n20.py` on the CA/TX n=20
+per-fold; verdicts not expected to move). The still-pending CPU item is the CA/TX *joint-best* n=20 re-score
+(closing_data_v2 task T6).

--- a/docs/studies/closing_data/v17_completion/A40.md
+++ b/docs/studies/closing_data/v17_completion/A40.md
@@ -8,7 +8,7 @@
 > `../HANDOFF_A40.md`.
 >
 > **⭐ Current queue (updated 2026-07-08 post-PR #61 — deadline mode, paper-closing data ONLY):**
-> **1.** **A1 (ex-H1) — CA/TX v17 MTL n=20 {1,7,100} — 🔄 RUNNING** (launched PR #61: `a1_catx/run_a1_catx_n20.sh`,
+> **1.** **A1 (ex-H1) — CA/TX v17 MTL n=20 {1,7,100} — ✅ DONE 2026-07-11** (`a1_catx/run_a1_catx_n20.sh`,
 > 1-wide fp32, RAM-gated ≥80 GB — each build peaks ~66 GB host RAM, 2-wide OOMs; resumable per-cell, 2× retry,
 > ~1.5 d) — **the last verdict-changer**; feeds M1-full. *(The July-1 {1,7,100} attempts had all host-RAM-OOM'd —
 > A1 was genuinely un-run.)*
@@ -46,7 +46,7 @@
 | **A2-azfl · ReHDM AZ/FL v4** (version-uniform row) | ✅ **DONE (PR #61)** | — | — | all-v4 row: AL 65.38 / **AZ 53.00** / **FL 64.49** / Istanbul 69.33; v2 row superseded (never cite) |
 | **A40-5 · P6 CA/TX** cascade coverage | ⬜ **OPEN** | cascade seed0×5f × {CA,TX} vs `catx_v17_seed0_5f/` champion | ≈1 champ-run/state | comparand exists; v17 recipe + 5 b4 pins (see A40-5) |
 | **n=20 stretches** (cascade / STAN {1,7,100}) | ⬜ **post-P1** | seeds {1,7,100}, robustness only | — | strictly below P1; carry no tested claim |
-| **A1 (ex-H1)** CA/TX v17 MTL n=20 {1,7,100} | 🔄 **RUNNING (launched PR #61)** | 6 cells complete as they land | ~1.5 d | driver `a1_catx/run_a1_catx_n20.sh` (1-wide fp32, RAM-gated ≥80 GB — the July-1 attempts host-RAM-OOM'd 2-wide; resumable per-cell, 2× retry); feeds **M1-full** |
+| **A1 (ex-H1)** CA/TX v17 MTL n=20 {1,7,100} | ✅ **DONE 2026-07-11** | M1-full stats re-run (`m1_stats_n20.py` on the n=20 per-fold) | — | **CA cat 77.052±0.006 / reg 65.693±0.017 · TX cat 77.239±0.014 / reg 67.062±0.007** (`catx_v17_n20/`). n=20 CONFIRMS seed-0 (Δcat +6.45/+7.45, Δreg +2.20/+2.11 vs n=20 ceilings). **v17 board complete.** 2-wide smoke: fits but GPU-bound → no benefit, stayed 1-wide |
 | **A1-az** AZ cat-ceiling screen top-up | ❌ **DROPPED (user decision 2026-07-08)** | — | — | AZ ceiling stays **56.43** (max full-n=20 arm, Δcat +9.40); the n=10 screens (57.04/56.93) stay disclosed-but-untested (`CEILINGS_N20_FINAL.md` banner). Paper-closing data takes priority |
 
 > **Region-external story is already carried** (HMT-GRN 6 states + faithful STAN AL/AZ/FL/Istanbul + the above), so
@@ -225,6 +225,16 @@ it's the last A40 task, after H2/H3.
   verdict, and C4 already scopes honestly to "the four datasets where we measured it". Do not register as a task.
 
 ## A1 (ex-H1) · CA/TX v17 MTL n=20, seeds {1,7,100} — **MIGRATED here 2026-07-08 (H100 gone); the verdict-changer**
+> ✅ **DONE 2026-07-11.** Ran on the A40 via `a1_catx/run_a1_catx_n20.sh` (1-wide fp32, RAM-gated ≥80 GB, resumable
+> per-cell, 2× retry — TX s100 auto-recovered a transient rc=132 crash). 6/6 cells: **CA cat 77.052±0.006 /
+> reg 65.693±0.017 · TX cat 77.239±0.014 / reg 67.062±0.007** (`docs/results/closing_data/catx_v17_n20/`). The n=20
+> **CONFIRMS** seed-0 (Δcat +6.45/+7.45, Δreg +2.20/+2.11 vs the n=20 ceilings) — **every v17 board cell is now n=20.**
+> Folded into `CEILINGS_N20_FINAL.md`, `RESULTS_BOARD §1`, `catx_v17_seed0_5f/RESULTS.md`, `stats_n20/RESULTS.md`.
+> A midnight-BRT auto-relaunch (`midnight_relaunch_a1.sh`) restarted it on a freed GPU; a 2-wide smoke proved
+> 2-wide fits RAM but is GPU-bound (no benefit) → stayed 1-wide. **Remaining: the M1-full stats re-run**
+> (`m1_stats_n20.py` on the n=20 per-fold) to lift the M1-PARTIAL/PROVISIONAL banners.
+>
+> *(Historical plan below — the seed-0 gap it describes is now closed.)*
 The one remaining board gap: the v17 MTL cells at CA/TX are seed-0 (n=5); everything else on the v17 board is n=20.
 Run serially, **fp32** (`MTL_DISABLE_AMP=1`), reusing the proven seed-0 driver:
 ```bash

--- a/docs/studies/closing_data/v17_completion/CEILINGS_N20_FINAL.md
+++ b/docs/studies/closing_data/v17_completion/CEILINGS_N20_FINAL.md
@@ -19,12 +19,12 @@
 | AL | 56.82 ±0.03 | 64.54 | **+7.72** ✅beats | 70.11 | 69.80 | **−0.31** ≈matches |
 | AZ | 56.43 ±0.10 † | 65.83 | **+9.40** ✅beats † | 59.46 | 59.56 | **+0.10** ≈matches |
 | FL | 74.51 ±0.03 | 79.85 | **+5.34** ✅beats | 76.70 | 77.42 | **+0.72** ✅beats |
-| CA | 70.60 ±0.07 | 77.04 | **+6.44** ✅beats | 63.49 | 65.69 | **+2.20** ✅beats |
-| TX | 69.79 ±0.08 | 77.23 | **+7.44** ✅beats | 64.95 | 67.07 | **+2.12** ✅beats |
+| CA | 70.60 ±0.07 | 77.05 | **+6.45** ✅beats | 63.49 | 65.69 | **+2.20** ✅beats |
+| TX | 69.79 ±0.08 | 77.24 | **+7.45** ✅beats | 64.95 | 67.06 | **+2.11** ✅beats |
 | Istanbul | 54.74 ±0.09 | 63.33 | **+8.59** ✅beats | 75.16 | 75.44 | **+0.28** ✅beats |
 
 **Story:** MTL beats the dedicated **category** ceiling at every state (+5.3 … +9.4 pp); **matches** the region ceiling at
-the small US states (AL −0.31, AZ +0.10, within δ=2 pp) and **beats** it at the larger ones (FL +0.72, CA +2.20, TX +2.12)
+the small US states (AL −0.31, AZ +0.10, within δ=2 pp) and **beats** it at the larger ones (FL +0.72, CA +2.20, TX +2.11)
 **and at Istanbul** (+0.28, non-US corpus, 520 mahalle — H3 dk_ovl+v17 rebuild; see `h3_istanbul/RESULTS.md`).
 
 > **Istanbul (added 2026-07-06, H3)** is v17 n=20 on the **rebuilt `dk_ovl` substrate** (v14/design_k re-windowed at
@@ -32,8 +32,11 @@ the small US states (AL −0.31, AZ +0.10, within δ=2 pp) and **beats** it at t
 > cross-substrate caveat is retired. Cat ceiling = small-state recipe bs2048@0.005; the rebuild lifted both heads vs the
 > old base (cat +6.69→+8.59, reg −0.52→+0.28).
 
-> ⚠ MTL cat/reg are n=20 at AL/AZ/FL (`perhead_lr_n20.md`) but **seed-0 (n=5) at CA/TX** (`catx_v17_seed0_5f`, fp32) —
-> the H1/H100 top-up ({1,7,100}) firms the large-state Δ significance. The **ceilings** here ARE n=20 at all 5 states.
+> ✅ **MTL cat/reg are now n=20 at ALL states** — CA/TX completed 2026-07-11 (A1 on the A40, `{1,7,100}` top-up;
+> per-cell scores `docs/results/closing_data/catx_v17_n20/`). The n=20 **confirms** the seed-0 values with tight
+> variance (CA cat 77.052 ±0.006 / reg 65.693 ±0.017; TX cat 77.239 ±0.014 / reg 67.062 ±0.007), so the CA/TX Δs
+> are now n=20-vs-n=20 (the seed-0 asterisks are dropped). Ceilings were already n=20 at all states. **The v17 board
+> is complete.**
 
 ## Category ceiling — recipe (best-vs-best, state-size-dependent)
 
@@ -65,4 +68,4 @@ verdict was correct; this makes the paired test rigorous.
 ## Provenance
 - cat: `cat_ceiling_sweep/{sweep.sh,aggregate.py,sweep_results/}` · driver logs `cat_ceiling_sweep/DRIVER.log`
 - reg: `reg_topup/{finalize_reg.sh,DRIVER.log}` · values `docs/results/closing_data/reg_ceiling_n20/`
-- MTL cat/reg: `perhead_lr_n20.md` (AL/AZ/FL n=20) · `catx_v17_seed0_5f/RESULTS.md` (CA/TX seed-0)
+- MTL cat/reg: `perhead_lr_n20.md` (AL/AZ/FL n=20) · `catx_v17_seed0_5f/RESULTS.md` + `docs/results/closing_data/catx_v17_n20/` (CA/TX n=20, A1 complete 2026-07-11)

--- a/docs/studies/closing_data/v17_completion/M2PRO.md
+++ b/docs/studies/closing_data/v17_completion/M2PRO.md
@@ -4,18 +4,21 @@
 > logits/JSONs, the pre-registered stats, the CPU-only leak audit, and the doc/LaTeX/submission work. Everything here
 > is CPU-bound and hours-scale. Recipe discipline (for any re-score): track [`README.md`](README.md).
 
-> **Sequencing (updated 2026-07-08, post-PR #58 — M1 is now PARTIALLY UNBLOCKED).** The ceilings are n=20 at all 6
-> datasets and the v17 MTL is n=20 at **AL/AZ/FL/Istanbul** → **M1-partial can run NOW at those 4** (fully n=20 on
-> both sides). Only the **CA/TX** cells wait on **A1 (ex-H1, now on the A40)**. M2–M5 are independent — anytime.
+> **Sequencing (updated 2026-07-11 — M1 is now FULLY UNBLOCKED).** The ceilings are n=20 at all 6 datasets and the
+> v17 MTL is now n=20 at **all 6** — the **CA/TX** cells landed with **A1 done 2026-07-11 on the A40** (`docs/results/closing_data/catx_v17_n20/`;
+> CA cat 77.052 ±0.006 / reg 65.693 ±0.017, TX cat 77.239 ±0.014 / reg 67.062 ±0.007 — confirms seed-0 within
+> <0.13 pp). → **M1-full can run NOW at all 6.** (Prior state: M1-partial at AL/AZ/FL/Istanbul while CA/TX waited on
+> A1, ex-H1.) M2–M5 are independent — anytime.
 
 ## Queue
 
-### M1 · v17 stats: Wilcoxon + TOST + per-cell Holm — **M1-partial NOW (AL/AZ/FL/Istanbul); CA/TX after A1**
-**NOW (M1-partial):** on the committed n=20 artifacts (no GPU, no waiting): pair the v17 MTL (AL/AZ/FL
-`perhead_lr_n20.md`; Istanbul `h3_istanbul/`) against the n=20 best-vs-best ceilings (`CEILINGS_N20_FINAL.md`,
-**AZ = 56.43 corrected**) → per-cell Wilcoxon (cat superiority) + TOST (reg matches) + Holm across the 4-dataset
-family; write the verdicts to a new `v17_completion/stats_n20/` record. **After A1 (CA/TX n=20, A40):** extend to
-all 6 → the full family Holm → drop "provisional" everywhere.
+### M1 · v17 stats: Wilcoxon + TOST + per-cell Holm — **M1-full NOW at all 6 (A1 done 2026-07-11)**
+**NOW (M1-full):** on the committed n=20 artifacts (no GPU, no waiting): pair the v17 MTL (AL/AZ/FL
+`perhead_lr_n20.md`; Istanbul `h3_istanbul/`; **CA/TX `docs/results/closing_data/catx_v17_n20/` — A1 done 2026-07-11
+on the A40**) against the n=20 best-vs-best ceilings (`CEILINGS_N20_FINAL.md`,
+**AZ = 56.43 corrected**) → per-cell Wilcoxon (cat superiority) + TOST (reg matches) + Holm across the full 6-dataset
+family; write the verdicts to a new `v17_completion/stats_n20/` record. The remaining step is to re-run
+`m1_stats_n20.py` on the CA/TX n=20 per-fold (verdicts not expected to move — the n=20 confirms seed-0 within <0.13 pp).
 Original spec (kept):
 - Re-score every §6.2 cell at n=20 via the matched scorer (`scripts/closing_data/h100_score_matched.py` /
   `r0_matched_rescore.py` read saved logits — no re-training).

--- a/docs/studies/closing_data/v17_completion/README.md
+++ b/docs/studies/closing_data/v17_completion/README.md
@@ -8,20 +8,20 @@
 
 ## Where v17 stands (what's DONE)
 - **v17 MTL n=20 at AL / AZ / FL** — DONE (`../perhead_lr_n20.md`): AL 64.54 / 69.80, AZ 65.84 / 59.56, FL 79.85 / 77.42.
-- **v17 MTL seed-0 5f at CA / TX** — DONE (`../catx_v17_seed0_5f/RESULTS.md`, fp32): CA 77.04 / 65.69, TX 77.23 / 67.07.
+- **v17 MTL n=20 at CA / TX** — ✅ **DONE 2026-07-11 (A1)** (`catx_v17_seed0_5f/RESULTS.md` + `docs/results/closing_data/catx_v17_n20/`, fp32): CA 77.052±0.006 / 65.693±0.017, TX 77.239±0.014 / 67.062±0.007 — n=20 confirms seed-0.
   **Finding: v17's cat lever is a STATE-SIZE trade** — wins small/mid (+0.2…+2.5), costs ~0.28 cat at CA/TX (real, not
   a bf16 artifact — TX board is fp32), reg-neutral+ everywhere. Kept board-wide.
 - **STL cat + reg ceilings (n=20, best-vs-best)** — ✅ **DONE 2026-07-03 (AZ corrected 2026-07-08), 5 Gowalla states →
   [`CEILINGS_N20_FINAL.md`](CEILINGS_N20_FINAL.md).**
   Cat re-tuned best-vs-best (per-state max: AL `bs2048@0.005`; AZ/FL/CA/TX `bs8192@0.005`); reg topped up to n=20.
-  Δcat = AL +7.72 / **AZ +9.40** / FL +5.34 / CA +6.44 / TX +7.44 (MTL beats cat ceiling everywhere).
-  Δreg = AL −0.31 / AZ +0.10 / FL +0.72 / CA +2.20 / TX +2.12 (matches small, beats large).
+  Δcat = AL +7.72 / **AZ +9.40** / FL +5.34 / CA +6.45 / TX +7.45 (MTL beats cat ceiling everywhere; CA/TX now n=20).
+  Δreg = AL −0.31 / AZ +0.10 / FL +0.72 / CA +2.20 / TX +2.11 (matches small, beats large; CA/TX now n=20).
   ⚠ AZ correction: the published 56.24 wasn't the per-state max — the n=20 `bs8192@0.005` arm is 56.43 (Δ +9.40, not
   +9.60); two higher n=10 screens (57.04/56.93) pending a cheap top-up (see A1-az in the A40 queue). **Istanbul: done via H3 (below).**
   > Prior audit note (kept for the record): the *old* `dk_ovl` board reg ceiling was seed-0 (n=5), not n=20 — the
   > "already n=20" claim conflated it with the v14 substrate (~9 pp different). Now genuinely n=20 on `dk_ovl`; reg is
   > seed-invariant (n=20 vs seed-0 diff < 0.13 pp), so the seed-0 verdict was correct — the top-up just makes the paired
-  > test rigorous. (MTL cat/reg at CA/TX are still seed-0 pending H1 — the ceilings are n=20.)
+  > test rigorous. (MTL cat/reg at CA/TX are now **n=20** too — A1 done 2026-07-11; the ceilings were already n=20.)
 - **H3 · Istanbul rebuilt on `dk_ovl` + v17 (n=20)** — ✅ **DONE 2026-07-06 → [`h3_istanbul/RESULTS.md`](h3_istanbul/RESULTS.md).**
   Same substrate identity as the 5 Gowalla states (cross-substrate caveat RETIRED). **Δcat +8.59 / Δreg +0.28 — beats
   BOTH** (reg flips positive vs the old stride-1-GCN base's −0.52). Baselines re-footed: CTLE-SC +28.73 / HGI +28.09 hold.
@@ -43,7 +43,7 @@
 
 | ID | Run / analysis | Machine | Status | Cost | Blocks |
 |----|---|---|---|---|---|
-| **A1 (ex-H1)** | **CA/TX v17 MTL n=20, seeds {1,7,100}** — MIGRATED from the H100 (lane gone) | **A40** | open, **top priority** | fp32 serial ~4.4–6.3 h/cell → ~1.5 d for 6 cells (proven by the seed-0 run) | large-state Δcat significance → M1 |
+| **A1 (ex-H1)** | **CA/TX v17 MTL n=20, seeds {1,7,100}** — MIGRATED from the H100 (lane gone) | **A40** | ✅ **DONE 2026-07-11** (`catx_v17_n20/`: CA 77.052/65.693, TX 77.239/67.062; n=20 confirms seed-0) | fp32 serial ~4.9/6.3 h/cell, 6 cells | firmed the large-state Δ → **M1-full** unblocked (re-run `m1_stats_n20.py`) |
 | **A1-az** | AZ cat-ceiling screen top-up: `bs2048@{0.0025,0.0075}` × seeds {7,100} | A40 | **DROPPED (user 2026-07-08; see A40.md)** — AZ ceiling stays 56.43/Δ+9.40; the paper carries a visible sensitivity clause (§6.2) | — | — |
 | **A2** | ReHDM v4: **CA/TX 🔄 RUNNING** (~22 h, resumable) + **AZ/FL v4 re-run** (version-uniform row; AL done 65.38) | A40 | running / open | AZ/FL ≈ ~25–60 min/state | ReHDM paper row (v4-uniform) |
 | **A3** | Faithful STAN CA/TX | A40 | ✅ **CLOSED-AS-PARTIAL** (user 2026-07-08): TX 61.67 (4/5) / CA 58.52 (2/5) = citable-final, fold counts disclosed | 0 h (remaining folds optional post-deadline) | Table-3 cells FILL NOW with the n-folds footnote |

--- a/docs/studies/closing_data/v17_completion/a1_catx/midnight_relaunch_a1.sh
+++ b/docs/studies/closing_data/v17_completion/a1_catx/midnight_relaunch_a1.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Midnight-BRT conditional A1 relaunch: at 00:00 BRT (03:00 UTC), once the GPU is idle, launch A1 1-WIDE.
+# (Smoke 2026-07-10 proved 2-wide fits RAM but is GPU-bound → no throughput benefit → stay 1-wide.)
+set -uo pipefail
+cd /home/vitor.oliveira/PoiMtlNet
+BASE=docs/studies/closing_data/v17_completion/a1_catx
+LOG="$BASE/midnight_launcher.log"
+log(){ echo "[$(date -u '+%F %T UTC') | $(TZ=America/Sao_Paulo date '+%T BRT')] $*" | tee -a "$LOG"; }
+
+# 1. sleep until the next 03:00 UTC == 00:00 BRT
+now=$(date -u +%s); target=$(date -u -d 'today 03:00' +%s); [ "$now" -ge "$target" ] && target=$(date -u -d 'tomorrow 03:00' +%s)
+log "launcher armed. Sleeping $((target-now))s (~$(( (target-now)/3600 ))h $(( ((target-now)%3600)/60 ))m) until midnight BRT."
+sleep $((target-now))
+log "midnight BRT reached — polling GPU until idle (only relaunch when nothing is running on the GPU)."
+
+# 2. poll until the GPU is idle (no compute-apps AND <500 MiB used)
+while :; do
+  used=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | head -1); used=${used:-9999}
+  apps=$(nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null | grep -c . || true)
+  if [ "${apps:-1}" -eq 0 ] && [ "$used" -lt 500 ]; then
+    log "GPU IDLE (used=${used}MiB, apps=${apps}) → launching A1 1-wide."; break
+  fi
+  log "GPU busy (used=${used}MiB, apps=${apps}) — re-check in 5min."; sleep 300
+done
+
+# 3. launch the A1 orchestrator (1-wide; its own ReHDM-wait passes instantly + RAM gate ≥80GB)
+setsid nohup bash "$BASE/run_a1_catx_n20.sh" > /dev/null 2>&1 < /dev/null &
+log "A1 orchestrator launched (1-wide, {1,7,100})."

--- a/docs/studies/closing_data/v17_completion/a1_catx/smoke_2wide.sh
+++ b/docs/studies/closing_data/v17_completion/a1_catx/smoke_2wide.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# 2-WIDE SMOKE: can 1 CA + 1 TX v17 MTL run concurrently (each dataset build peaks ~66 GB host RAM) and is
+# there a throughput benefit vs 1-wide? Truncated A1 recipe: --only-fold 0 --epochs 3 (full dataset still built,
+# so the ~66 GB RAM peak is representative). Samples MemAvailable throughout. NON-destructive smoke.
+set -uo pipefail
+cd /home/vitor.oliveira/PoiMtlNet
+source /home/vitor.oliveira/.venv/bin/activate
+OVL=check2hgi_dk_ovl; V14=check2hgi_design_k_resln_mae_l0_1
+BASE=docs/studies/closing_data/v17_completion/a1_catx/smoke2wide
+mkdir -p "$BASE"
+DRV="$BASE/DRIVER.log"; : > "$DRV"
+log(){ echo "[$(date '+%T')] $*" | tee -a "$DRV"; }
+
+# background RAM sampler (min MemAvailable = the tightest point)
+( echo "min_avail_gb=999"; while true; do
+    a=$(awk '/MemAvailable/{printf "%.1f",$2/1048576}' /proc/meminfo)
+    echo "$(date '+%T') $a"; sleep 4
+  done ) > "$BASE/ram.log" 2>&1 &
+SAMPLER=$!
+
+run_one(){ local st=$1
+  export PYTHONPATH=src MTL_DISABLE_AMP=1 MTL_ONECYCLE_PER_HEAD_LR=1 MTL_CHUNK_VAL_METRIC=1 MTL_STRICT=1 MTL_COMPILE_DYNAMIC=1
+  export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
+  export MTL_RAM_HEADROOM_GB=2                # permissive: let a REAL OOM (not the guard) reveal the limit
+  export TORCHINDUCTOR_CACHE_DIR="$HOME/.inductor_cache_smoke2w_${st}"
+  python scripts/train.py --task mtl --canon none --task-set check2hgi_next_region --engine "$OVL" \
+    --state "$st" --seed 1 --epochs 3 --folds 5 --only-fold 0 --batch-size 8192 \
+    --mtl-loss static_weight --category-weight 0.75 --no-reg-class-weights --no-cat-class-weights \
+    --cat-head next_gru --reg-head next_stan_flow_dualtower \
+    --reg-head-param raw_embed_dim=64 --reg-head-param fusion_mode=aux \
+    --reg-head-param freeze_alpha=True --reg-head-param alpha_init=0.0 \
+    --task-a-input-type checkin --task-b-input-type region --log-t-kd-weight 0.0 \
+    --scheduler onecycle --max-lr 3e-3 --cat-lr 1e-3 --reg-lr 3e-3 --shared-lr 1e-3 \
+    --model mtlnet_crossattn_dualtower --checkpoint-selector geom_simple --compile --tf32 \
+    --per-fold-transition-dir "output/$V14/$st" --no-checkpoints > "$BASE/smoke_${st}.log" 2>&1
+  echo "  ${st} rc=$? " >> "$DRV"
+}
+
+log "2-wide smoke START (CA + TX concurrent, only-fold 0, 3 epochs). start RAM avail=$(awk '/MemAvailable/{printf "%.1f",$2/1048576}' /proc/meminfo) GB"
+run_one california & CA=$!
+run_one texas & TX=$!
+wait $CA; rc_ca=$?
+wait $TX; rc_tx=$?
+kill $SAMPLER 2>/dev/null || true
+
+log "both finished (rc_ca=$rc_ca rc_tx=$rc_tx). Analysis:"
+python - <<'PY' 2>&1 | tee -a "$DRV"
+import re
+BASE="docs/studies/closing_data/v17_completion/a1_catx/smoke2wide"
+# min RAM avail during the run
+vals=[float(l.split()[1]) for l in open(f"{BASE}/ram.log") if len(l.split())==2 and l.split()[1].replace('.','').isdigit()]
+print(f"  MIN MemAvailable during 2-wide = {min(vals):.1f} GB (of 125.6)  -> {'FITS' if min(vals)>3 else 'NEAR-OOM'}")
+# per-epoch dt each state; OOM check
+for st in ["california","texas"]:
+    t=open(f"{BASE}/smoke_{st}.log").read()
+    oom = bool(re.search(r"out of memory|OutOfMemory|MemoryError|Killed|non-finite", t, re.I))
+    dts=[float(x) for x in re.findall(r"dt=([0-9.]+)s", t)]
+    eps=re.findall(r"Fold \d/5 completed in ([0-9.]+)s", t)
+    # tqdm rate
+    rate=re.findall(r"([0-9.]+)batch/s", t); rate=rate[-1] if rate else "?"
+    print(f"  {st:11} oom={oom}  per-epoch dt={dts if dts else 'n/a'}  last_batch_rate={rate}/s  fold-time={eps or 'n/a'}")
+print("\n  1-WIDE baseline (CA fold ~3595s/50ep => ~72s/epoch). If 2-wide per-epoch <~1.6x the 1-wide, 2-wide WINS on throughput.")
+PY
+log "2-wide smoke COMPLETE"

--- a/docs/studies/closing_data/v17_completion/stats_n20/RESULTS.md
+++ b/docs/studies/closing_data/v17_completion/stats_n20/RESULTS.md
@@ -86,7 +86,15 @@ cannot clear α until the per-fold n=20 vectors land).
    correction is reported on the t p-values; all four reject at FWER 0.05 (smallest margin: adj
    p = 5.3e-07).
 
-## 1b · CA / TX — **PROVISIONAL n=5 (seed-0, per-fold paired; superseded by A1's n=20)**
+## 1b · CA / TX — seed-0 paired analysis (✅ **A1 n=20 now COMPLETE — supersede via M1-full re-run**)
+
+> ✅ **A1 DONE 2026-07-11** — CA/TX v17 MTL is now **n=20** (`docs/results/closing_data/catx_v17_n20/`; means
+> CA cat 77.052 ±0.006 / reg 65.693 ±0.017, TX cat 77.239 ±0.014 / reg 67.062 ±0.007). The n=20 **confirms** the
+> provisional seed-0 verdicts below with tight cross-seed variance (all four cells still beat their n=20 ceilings:
+> CA +6.45/+2.20, TX +7.45/+2.11). **The seed-0 paired tests below are retained as the provisional footing; the
+> M1-FULL step is to re-run `m1_stats_n20.py` on the CA/TX n=20 per-fold vectors** (now extractable from the A1
+> rundirs) so the 6-dataset family Holm runs at full n=20 and the PROVISIONAL/M1-PARTIAL banners lift. The verdicts
+> are not expected to move (the n=20 means match seed-0 to <0.13 pp).
 
 **Footing (state it precisely):** the **cited ceiling means stay the n=20 values** (CA cat 70.60 /
 reg 63.49; TX cat 69.79 / reg 64.95 — `CEILINGS_N20_FINAL.md`); the **paired tests below use the
@@ -117,11 +125,11 @@ mean while the paired vectors are seed-0 (seed-0 ceiling ≈ +0.12/+0.13 above t
 
 ## 2 · LIMITS (honest gaps — read before citing)
 
-1. **CA/TX are PROVISIONAL (n=5, seed-0 MTL side)** — the v17 MTL n=20 top-up is **A1** on the A40
-   (`../A40.md`); seed 0 is a single-seed footing (development-seed caveats apply; the CA/TX STL
-   **ceilings** are n=20 and seed-invariant, so the provisional risk sits on the MTL side only).
-   The 6-dataset family Holm (protocol §5.2) re-runs after A1. Until then every verdict here
-   carries the M1-PARTIAL banner and the §1b cells carry PROVISIONAL.
+1. **CA/TX MTL n=20 is now DONE (A1, 2026-07-11)** — the provisional risk that sat on the seed-0 MTL
+   side is resolved: n=20 means confirm seed-0 to <0.13 pp (CA cat 77.052/reg 65.693, TX cat 77.239/
+   reg 67.062). ⏳ **Remaining (M1-full compute, not a doc edit):** re-run `m1_stats_n20.py` on the CA/TX
+   n=20 per-fold vectors (extract from the A1 rundirs) → the 6-dataset family Holm at full n=20, which
+   **lifts the M1-PARTIAL banner + the §1b PROVISIONAL labels**. Verdicts not expected to move.
 2. **All §1 cells are seed-level (n=4), not per-fold (n=20).** Still missing from the committed tree
    (A40 gitignored rundirs):
    - AL/AZ/FL: the per-PID `a40_score_matched.py` sidecar JSONs (tags `n20ph_{state}_{recipe}_s{seed}`,

--- a/docs/studies/closing_data/v17_completion/stats_n20/RESULTS.md
+++ b/docs/studies/closing_data/v17_completion/stats_n20/RESULTS.md
@@ -1,4 +1,29 @@
-# M1-PARTIAL — v17 pre-registered stats vs the n=20 best-vs-best ceilings (2026-07-08, rev 3)
+# M1-FULL — v17 pre-registered stats vs the n=20 best-vs-best ceilings (rev 4, 2026-07-13)
+
+> ✅ **M1-FULL (rev 4, 2026-07-13) — A1 landed CA/TX v17 MTL n=20 (2026-07-11); the pre-registered
+> 6-dataset family Holm now runs.** Re-run `m1_stats_n20.py` (§5 appended; full log `m1_full_output.txt`).
+> All artifact→board reproduction gates pass, incl. the new CA/TX n=20 (CA cat 77.052/reg 65.693,
+> TX cat 77.239/reg 67.062). **Result — the 6-dataset cat-superiority family Holm ALL REJECT @ α=0.05:**
+>
+> | dataset | Δcat (pp) | paired t(3) p | Holm-adj (m=6) | reject |
+> |---|---:|---:|---:|:--:|
+> | AL | +7.73 | 4.5e-07 | 8.9e-07 | ✅ |
+> | AZ | +9.40 | 2.1e-07 | 8.9e-07 | ✅ |
+> | FL | +5.34 | 4.2e-09 | 2.5e-08 | ✅ |
+> | Istanbul | +8.59 | 1.8e-07 | 8.9e-07 | ✅ |
+> | **CA** | **+6.45** (4/4) | 3.8e-07 | 8.9e-07 | ✅ |
+> | **TX** | **+7.45** (4/4) | 2.5e-07 | 8.9e-07 | ✅ |
+>
+> **MTL beats the dedicated category ceiling at every dataset** (Holm-adj ≤ 8.9e-07). Reg (per-axis δ=2 pp):
+> matches at AL/AZ, **beats** at FL/CA/TX/Istanbul — CA reg Δ+2.20 (90% CI +2.193…+2.215, entirely above +δ;
+> superiority t(3) p=1.0e-08), TX reg Δ+2.11 (superiority t(3) p=1.4e-07). The n=20 **CONFIRMS** the seed-0
+> provisional verdicts (§3) — **no verdict changed.** The seed-level test is n=4-paired (per protocol §8's
+> powered-t deviation; the exact-Wilcoxon floor is 0.0625 at n=4). The PROVISIONAL/M1-PARTIAL material below is
+> retained for the record.
+
+---
+
+## (superseded) M1-PARTIAL — rev 3, 2026-07-08
 
 > ⚠ **This is M1-PARTIAL.** The fully-n=20 family covers **AL, AZ, FL, Istanbul** (ceilings per
 > [`../CEILINGS_N20_FINAL.md`](../CEILINGS_N20_FINAL.md), **AZ ceiling = 56.43, the corrected

--- a/docs/studies/closing_data/v17_completion/stats_n20/m1_full_output.txt
+++ b/docs/studies/closing_data/v17_completion/stats_n20/m1_full_output.txt
@@ -1,0 +1,125 @@
+========================================================================================
+M1-PARTIAL — v17 vs n=20 best-vs-best ceilings (AL/AZ/FL/Istanbul); CA/TX await A1
+========================================================================================
+
+--- 0 · artifact -> board reproduction gate ---
+  [OK] AL STL cat ceiling (n=20): recomputed 56.8151 vs board 56.82
+  [OK] AZ STL cat ceiling (n=20): recomputed 56.4349 vs board 56.43
+  [OK] FL STL cat ceiling (n=20): recomputed 74.5087 vs board 74.51
+  [OK] AL STL reg ceiling (n=20): recomputed 70.1109 vs board 70.11
+  [OK] AZ STL reg ceiling (n=20): recomputed 59.4595 vs board 59.46
+  [OK] FL STL reg ceiling (n=20): recomputed 76.6973 vs board 76.7
+  [OK] Istanbul STL reg ceiling (n=20): recomputed 75.1584 vs board 75.16
+  [OK] AL MTL v17 cat (n=20, tsv): recomputed 64.5405 vs board 64.54
+  [OK] AL MTL v17 reg (n=20, tsv): recomputed 69.8005 vs board 69.801
+  [OK] AZ MTL v17 cat (n=20, tsv): recomputed 65.8354 vs board 65.835
+  [OK] AZ MTL v17 reg (n=20, tsv): recomputed 59.5630 vs board 59.563
+  [OK] FL MTL v17 cat (n=20, tsv): recomputed 79.8481 vs board 79.848
+  [OK] FL MTL v17 reg (n=20, tsv): recomputed 77.4209 vs board 77.421
+  [OK] Istanbul MTL cat (n=20): recomputed 63.3287 vs board 63.33
+  [OK] Istanbul MTL reg (n=20): recomputed 75.4398 vs board 75.44
+  [OK] Istanbul STL cat ceiling (n=20): recomputed 54.7375 vs board 54.74
+
+--- 1 · per-dataset tests — SEED-LEVEL paired, n=4 (per-seed 5-fold means) ---
+
+  AL
+    CAT superiority (MTL > ceiling): Δ=+7.725 ± 0.115 pp, pairs+=4/4, per-seed Δ=[7.7258, 7.8796, 7.6039, 7.6923]
+      exact one-sided Wilcoxon p = 0.0625 (n=4 floor = 0.0625); paired t(3) one-sided p = 4.54e-07 (Δ ≈ 67σ_d)
+    REG TOST (δ_reg = 2 pp): Δ=-0.310 ± 0.146 pp, per-seed Δ=[-0.1298, -0.4609, -0.3893, -0.2616]
+      TOST p = 8.82e-05; 90% CI = (-0.482, -0.139) pp -> NON-INFERIOR (CI within ±2)
+
+  AZ
+    CAT superiority (MTL > ceiling): Δ=+9.400 ± 0.108 pp, pairs+=4/4, per-seed Δ=[9.4017, 9.4108, 9.2627, 9.5265]
+      exact one-sided Wilcoxon p = 0.0625 (n=4 floor = 0.0625); paired t(3) one-sided p = 2.09e-07 (Δ ≈ 87σ_d)
+    REG TOST (δ_reg = 2 pp): Δ=+0.103 ± 0.087 pp, per-seed Δ=[0.225, 0.0294, 0.0543, 0.1051]
+      TOST p = 1.33e-05; 90% CI = (+0.001, +0.206) pp -> NON-INFERIOR (CI within ±2)
+      (CI entirely > 0 -> descriptively beats; supplementary Wilcoxon p = 0.0625 [n=4 floor], paired t p = 4.88e-02)
+
+  FL
+    CAT superiority (MTL > ceiling): Δ=+5.339 ± 0.017 pp, pairs+=4/4, per-seed Δ=[5.3218, 5.3432, 5.3316, 5.3606]
+      exact one-sided Wilcoxon p = 0.0625 (n=4 floor = 0.0625); paired t(3) one-sided p = 4.20e-09 (Δ ≈ 320σ_d)
+    REG TOST (δ_reg = 2 pp): Δ=+0.724 ± 0.044 pp, per-seed Δ=[0.6787, 0.7124, 0.7183, 0.7849]
+      TOST p = 5.83e-06; 90% CI = (+0.671, +0.776) pp -> NON-INFERIOR (CI within ±2)
+      (CI entirely > 0 -> descriptively beats; supplementary Wilcoxon p = 0.0625 [n=4 floor], paired t p = 3.19e-05)
+
+  Istanbul
+    CAT superiority (MTL > ceiling): Δ=+8.591 ± 0.094 pp, pairs+=4/4, per-seed Δ=[8.6116, 8.4691, 8.5882, 8.6958]
+      exact one-sided Wilcoxon p = 0.0625 (n=4 floor = 0.0625); paired t(3) one-sided p = 1.78e-07 (Δ ≈ 92σ_d)
+    REG TOST (δ_reg = 2 pp): Δ=+0.281 ± 0.035 pp, per-seed Δ=[0.2503, 0.3081, 0.2514, 0.3159]
+      TOST p = 1.21e-06; 90% CI = (+0.240, +0.323) pp -> NON-INFERIOR (CI within ±2)
+      (CI entirely > 0 -> descriptively beats; supplementary Wilcoxon p = 0.0625 [n=4 floor], paired t p = 2.71e-04)
+
+--- 2 · Holm across the 4-dataset cat-superiority family (M1-PARTIAL, m=4) ---
+  Pre-registered test (Wilcoxon): every cell sits AT the n=4 exact floor 0.0625 with 4/4
+  positive -> Holm-adjusted 0.25 at best; the family CANNOT clear α=0.05 on Wilcoxon at
+  seed-level n=4 (a power ceiling, not evidence against — §2's n=5-ceiling analogue).
+  Powered seed-level analysis (paired t(3), deviation-logged per §8):
+    AL        Δcat= +7.73  t-p=4.54e-07  Holm_adj=5.34e-07  reject@.05=True
+    AZ        Δcat= +9.40  t-p=2.09e-07  Holm_adj=5.34e-07  reject@.05=True
+    FL        Δcat= +5.34  t-p=4.20e-09  Holm_adj=1.68e-08  reject@.05=True
+    Istanbul  Δcat= +8.59  t-p=1.78e-07  Holm_adj=5.34e-07  reject@.05=True
+  Reg TOST cells are equivalence tests with their own δ_reg verdict — NOT pooled into
+  the cat Holm family (protocol §5.2).
+
+  ⚠ M1-PARTIAL: the paper's headline family is 6 datasets (protocol §5.2). The full
+    6-dataset Holm re-runs after A1 lands CA/TX v17 MTL n=20 on the A40; the per-fold
+    (n=20) upgrade of ALL cells additionally needs the matched-score sidecars pulled
+    (see RESULTS.md LIMITS).
+
+--- 3 · CA/TX — PROVISIONAL, per-fold PAIRED at seed 0 (n=5; Wilcoxon floor 0.0312) ---
+  MTL = catx_v17_seed0_5f (matched-scorer per-fold, parsed from its RESULTS.md — the
+  only committed carrier; cat cross-checked vs profile.json, means vs summary.tsv).
+  STL = the SEED-0 fold vectors of the same runs whose n=20 means are the cited
+  ceilings (CEILINGS_N20_FINAL: CA cat 70.60 / reg 63.49; TX cat 69.79 / reg 64.95) —
+  the CITED ceiling stays n=20; only the paired test is at the seed-0 footing.
+  NOT in the m=4 Holm family; the 6-dataset family Holm waits for A1.
+
+  CA (PROVISIONAL, seed-0)
+    CAT superiority: Δ=+6.315 ± 0.167 pp, folds+=5/5, per-fold Δ=[6.4834, 6.4647, 6.2354, 6.3086, 6.0812]
+      exact one-sided Wilcoxon p = 0.0312 (n=5 floor = 0.0312 — at-ceiling if 5/5); paired t(4) p = 5.89e-08
+    REG (δ_reg = 2 pp): Δ=+2.207 ± 0.073 pp, per-fold Δ=[2.1466, 2.1113, 2.2736, 2.2418, 2.2627]
+      TOST non-inferiority side p = 1.11e-08; 90% CI = (+2.137, +2.277) pp
+      -> CI entirely ABOVE +δ: exceeds the margin in the FAVORABLE direction (two-sided equivalence n/a — better than the margin); non-inferiority trivially holds.
+      superiority (the pre-registered reg-'beats' family, superiority_wilcoxon.py): Wilcoxon p = 0.0312, folds+=5/5, paired t(4) p = 1.47e-07
+
+  TX (PROVISIONAL, seed-0)
+    CAT superiority: Δ=+7.312 ± 0.395 pp, folds+=5/5, per-fold Δ=[7.3109, 7.4994, 6.6299, 7.5948, 7.5238]
+      exact one-sided Wilcoxon p = 0.0312 (n=5 floor = 0.0312 — at-ceiling if 5/5); paired t(4) p = 1.02e-06
+    REG (δ_reg = 2 pp): Δ=+2.110 ± 0.069 pp, per-fold Δ=[2.1441, 2.1844, 2.1261, 2.0004, 2.0966]
+      TOST non-inferiority side p = 9.64e-09; 90% CI = (+2.044, +2.176) pp
+      -> CI entirely ABOVE +δ: exceeds the margin in the FAVORABLE direction (two-sided equivalence n/a — better than the margin); non-inferiority trivially holds.
+      superiority (the pre-registered reg-'beats' family, superiority_wilcoxon.py): Wilcoxon p = 0.0312, folds+=5/5, paired t(4) p = 1.39e-07
+
+  [provisional] These n=5 seed-0 verdicts are superseded by A1's n=20 the moment it lands.
+
+========================================================================================
+M1-FULL — CA/TX v17 MTL n=20 (A1 2026-07-11); the pre-registered 6-dataset family Holm
+========================================================================================
+  [OK] CA MTL v17 cat (n=20): recomputed 77.0520 vs board 77.052
+  [OK] CA MTL v17 reg (n=20): recomputed 65.6932 vs board 65.693
+  [OK] CA STL cat ceiling (n=20): recomputed 70.6041 vs board 70.6
+  [OK] TX MTL v17 cat (n=20): recomputed 77.2390 vs board 77.239
+  [OK] TX MTL v17 reg (n=20): recomputed 67.0619 vs board 67.062
+  [OK] TX STL cat ceiling (n=20): recomputed 69.7921 vs board 69.79
+
+--- CA/TX seed-level tests (n=4, paired by seed) ---
+
+  CA   CAT Δ=+6.448±0.090 pp, pairs+=4/4, per-seed Δ=[6.3149, 6.5129, 6.4877, 6.4761]
+        Wilcoxon p=0.0625 (n=4 floor 0.0625); paired t(3) p=3.75e-07
+      REG Δ=+2.204±0.009 pp, 90% CI=(+2.193,+2.215); superiority Wilcoxon p=0.0625 t(3) p=1.04e-08
+
+  TX   CAT Δ=+7.447±0.091 pp, pairs+=4/4, per-seed Δ=[7.313, 7.4992, 7.4665, 7.5089]
+        Wilcoxon p=0.0625 (n=4 floor 0.0625); paired t(3) p=2.52e-07
+      REG Δ=+2.115±0.012 pp, 90% CI=(+2.101,+2.130); superiority Wilcoxon p=0.0625 t(3) p=2.64e-08
+
+--- 6-dataset cat-superiority family Holm (M1-FULL, m=6; powered paired t) ---
+    AL        Δcat= +7.73  t-p=4.54e-07  Holm_adj=8.91e-07  reject@.05=True
+    AZ        Δcat= +9.40  t-p=2.09e-07  Holm_adj=8.91e-07  reject@.05=True
+    FL        Δcat= +5.34  t-p=4.20e-09  Holm_adj=2.52e-08  reject@.05=True
+    Istanbul  Δcat= +8.59  t-p=1.78e-07  Holm_adj=8.91e-07  reject@.05=True
+    CA        Δcat= +6.45  t-p=3.75e-07  Holm_adj=8.91e-07  reject@.05=True
+    TX        Δcat= +7.45  t-p=2.52e-07  Holm_adj=8.91e-07  reject@.05=True
+
+  M1-FULL VERDICT: 6-dataset cat family ALL REJECT @ α=0.05 — MTL beats the category ceiling at every dataset
+  Reg (per-axis δ=2 pp): matches at AL/AZ, beats at FL/CA/TX/Istanbul (TOST + superiority above).
+  n=20 CONFIRMS the seed-0 provisional verdicts (§3) — no verdict changed.

--- a/docs/studies/closing_data/v17_completion/stats_n20/m1_stats_n20.py
+++ b/docs/studies/closing_data/v17_completion/stats_n20/m1_stats_n20.py
@@ -333,3 +333,66 @@ for k in ["CA", "TX"]:
     print(f"      superiority (the pre-registered reg-'beats' family, superiority_wilcoxon.py): "
           f"Wilcoxon p = {supr['p_wilcoxon']:.4f}, folds+={supr['pos']}, paired t(4) p = {supr['p_t']:.2e}")
 print("\n  [provisional] These n=5 seed-0 verdicts are superseded by A1's n=20 the moment it lands.")
+
+
+# ===========================================================================
+# 5 · M1-FULL — CA/TX v17 MTL n=20 landed (A1, 2026-07-11); the 6-dataset Holm
+# ===========================================================================
+print("\n" + "=" * 88)
+print("M1-FULL — CA/TX v17 MTL n=20 (A1 2026-07-11); the pre-registered 6-dataset family Holm")
+print("=" * 88)
+
+CATX_CAT_CEIL = {"CA": "california_bs8192_lr0.005", "TX": "texas_bs8192_lr0.005"}
+CATX_REG_CEIL = {
+    "CA": {0: "region_head_california_region_5f_50ep_ca_ovl_stl_reg_s0.json",
+           1: "region_head_california_region_5f_50ep_california_ovl_stl_reg_topup_s1.json",
+           7: "region_head_california_region_5f_50ep_california_ovl_stl_reg_topup_s7.json",
+           100: "region_head_california_region_5f_50ep_california_ovl_stl_reg_topup_s100.json"},
+    "TX": {0: "region_head_texas_region_5f_50ep_tx_ovl_stl_reg_s0.json",
+           1: "region_head_texas_region_5f_50ep_texas_ovl_stl_reg_topup_s1.json",
+           7: "region_head_texas_region_5f_50ep_texas_ovl_stl_reg_topup_s7.json",
+           100: "region_head_texas_region_5f_50ep_texas_ovl_stl_reg_topup_s100.json"},
+}
+# CA/TX MTL seed-means: seed-0 (canonical seed0_5f matched-score) + {1,7,100} (A1 sidecars committed):
+CATX_MTL_S0 = {"CA": (77.0422, 65.6940), "TX": (77.2272, 67.0723)}
+SIDE = REPO / "docs/results/closing_data/catx_v17_n20"
+
+for k, stt in (("CA", "california"), ("TX", "texas")):
+    mtl_cat = [CATX_MTL_S0[k][0]]
+    mtl_reg = [CATX_MTL_S0[k][1]]
+    for s in (1, 7, 100):
+        sd = json.load(open(SIDE / f"{stt}_s{s}.json"))
+        mtl_cat.append(sd["cat_macro_f1_mean"])
+        mtl_reg.append(sd["reg_full_top10_mean"])
+    stl_cat = [st.mean(json.load(open(SWEEP / f"{CATX_CAT_CEIL[k]}_s{s}.json"))["cat_per_fold"]) for s in SEEDS]
+    stl_reg = [st.mean([x["top10_acc"] * 100
+                        for x in json.load(open(P1 / CATX_REG_CEIL[k][s]))["heads"]["next_stan_flow"]["per_fold"]])
+               for s in SEEDS]
+    ARMS[k] = dict(mtl_cat=mtl_cat, stl_cat=stl_cat, mtl_reg=mtl_reg, stl_reg=stl_reg)
+    check(f"{k} MTL v17 cat (n=20)", st.mean(mtl_cat), {"CA": 77.052, "TX": 77.239}[k])
+    check(f"{k} MTL v17 reg (n=20)", st.mean(mtl_reg), {"CA": 65.693, "TX": 67.062}[k])
+    check(f"{k} STL cat ceiling (n=20)", st.mean(stl_cat), {"CA": 70.60, "TX": 69.79}[k], tol=0.05)
+
+print("\n--- CA/TX seed-level tests (n=4, paired by seed) ---")
+for k in ["CA", "TX"]:
+    a = ARMS[k]
+    sup = paired_superiority(a["mtl_cat"], a["stl_cat"], "n=4 seeds")
+    tost = paired_tost(a["mtl_reg"], a["stl_reg"], "n=4 seeds")
+    supr = paired_superiority(a["mtl_reg"], a["stl_reg"], "n=4 seeds")
+    cat_res[k], reg_res[k] = sup, tost
+    print(f"\n  {k}   CAT Δ={sup['mean_d']:+.3f}±{sup['sd_d']:.3f} pp, pairs+={sup['pos']}, per-seed Δ={sup['d']}")
+    print(f"        Wilcoxon p={sup['p_wilcoxon']:.4f} (n=4 floor 0.0625); paired t(3) p={sup['p_t']:.2e}")
+    print(f"      REG Δ={tost['mean_d']:+.3f}±{tost['sd_d']:.3f} pp, 90% CI=({tost['ci90'][0]:+.3f},{tost['ci90'][1]:+.3f}); "
+          f"superiority Wilcoxon p={supr['p_wilcoxon']:.4f} t(3) p={supr['p_t']:.2e}")
+
+print("\n--- 6-dataset cat-superiority family Holm (M1-FULL, m=6; powered paired t) ---")
+t_family6 = [(k, cat_res[k]["p_t"]) for k in ["AL", "AZ", "FL", "Istanbul", "CA", "TX"]]
+t_holm6 = holm(t_family6)
+for k, p in t_family6:
+    padj, rej = t_holm6[k]
+    print(f"    {k:9s} Δcat={cat_res[k]['mean_d']:+6.2f}  t-p={p:.2e}  Holm_adj={padj:.2e}  reject@.05={rej}")
+allrej = all(t_holm6[k][1] for k, _ in t_family6)
+print(f"\n  M1-FULL VERDICT: 6-dataset cat family "
+      f"{'ALL REJECT @ α=0.05 — MTL beats the category ceiling at every dataset' if allrej else 'NOT all reject'}")
+print("  Reg (per-axis δ=2 pp): matches at AL/AZ, beats at FL/CA/TX/Istanbul (TOST + superiority above).")
+print("  n=20 CONFIRMS the seed-0 provisional verdicts (§3) — no verdict changed.")

--- a/docs/studies/closing_data_v2/AUDIT.md
+++ b/docs/studies/closing_data_v2/AUDIT.md
@@ -43,9 +43,12 @@ The joint-best point estimate is lower, so the up-arrow cells were stress-tested
 - **FL uses the `new` bs8192 per-head runs** (diag cat 79.848 = paper 79.85), not the bs2048 `base`.
 - **Recipe verified v17** from `model_params.json`: bs 8192, OneCycle per-head max_lr cat 1e-3 / reg 3e-3 / shared
   3e-3 (per-head LR APPLIED, not uniform), static_weight 0.75/0.25, AdamW wd 0.05.
-- **CA/TX A1 (n=20) genuinely incomplete on disk:** only a dead CA seed-1 attempt (rundir 742357, 4/5 folds, no
-  sidecar) exists; no CA s7/s100, no TX seeds. `a1_DRIVER.log` shows A1 launched only CA s1 (2026-07-08 19:14) then
-  stopped. → CA/TX correctly stay **seed-0 5f provisional** (task T6 remains blocked on A1).
+- **CA/TX A1 (n=20) genuinely incomplete on disk *at audit time*:** only a dead CA seed-1 attempt (rundir 742357,
+  4/5 folds, no sidecar) existed; no CA s7/s100, no TX seeds. `a1_DRIVER.log` showed A1 launched only CA s1
+  (2026-07-08 19:14) then stopped. → CA/TX correctly stayed **seed-0 5f provisional** for this joint-best re-score.
+  **UPDATE: A1 has since completed 2026-07-11 on the A40** (CA/TX v17 MTL n=20, `docs/results/closing_data/catx_v17_n20/`);
+  the n=20 diag-best confirms the seed-0 values within <0.13 pp. The *joint-best* n=20 re-score (task T6) is now
+  unblocked (CPU-only) but not yet run, so the seed-0 joint-best cells above stand until it is.
 - **STL "Dedicated" ceilings need no joint-best re-score** — a single-task checkpoint is picked on that task's own
   metric = its diag-best (joint-best == diag-best by construction; `score_joint_best.py` can't even run on an STL
   rundir, it requires paired cat+reg CSVs).
@@ -58,4 +61,6 @@ The joint-best point estimate is lower, so the up-arrow cells were stress-tested
    update the note to cite the actual joint-best numbers (they *confirm* the reported cells, within 0.1 pp).
 2. **If joint-best is ever RENDERED in place of a diag-best cell**, re-verify TOST/CI on the three thin reg cells
    only (AL −0.42, Istanbul +0.19, AZ −0.00); every cat beat and the FL/TX/CA reg ↑ are safe (task T7).
-3. **CA/TX at n=20** (task T6) is the only genuinely open item, and it is blocked on the A1 GPU top-up, not on J1.
+3. **CA/TX at n=20** (task T6) is the only genuinely open item. The A1 GPU top-up it depended on is **done
+   (2026-07-11, A40)** — so T6 is now a CPU-only re-score (re-run T2 `score_joint_best.py` on the CA/TX n=20 rundirs),
+   no longer GPU-blocked. The n=20 diag-best already confirms the seed-0 cells within <0.13 pp.

--- a/docs/studies/closing_data_v2/JOINT_BEST_RESULTS.md
+++ b/docs/studies/closing_data_v2/JOINT_BEST_RESULTS.md
@@ -20,7 +20,10 @@ numerically negligible for these well-converged v17 runs (every joint epoch land
 
 Category = macro-F1, region = Acc@10 (FULL = top10_acc_indist·(1−ood_frac)). "Dedicated" = the n=20 best-vs-best
 single-task ceiling (`CEILINGS_N20_FINAL.md`, unchanged). n=20 = 4 seeds {0,1,7,100}×5f (± cross-seed sd);
-CA/TX = seed-0 ×5f provisional (± fold sd).
+CA/TX = seed-0 ×5f (± fold sd) for this joint-best re-score — the n=20 *joint-best* pass is task T6 (CPU, now
+unblocked: **A1, the CA/TX v17 MTL n=20 GPU top-up, completed 2026-07-11 on the A40**; the n=20 diag-best confirms
+these seed-0 values within <0.13 pp — CA cat 77.052 / reg 65.693, TX cat 77.239 / reg 67.062,
+`docs/results/closing_data/catx_v17_n20/`).
 
 ### Next-category (macro-F1)
 | Dataset | Regions | Dedicated | Joint **diag-best** | Joint **joint-best (deploy)** | Δdeploy−diag |
@@ -96,9 +99,10 @@ see [`AUDIT.md`](AUDIT.md).
 - **Recommended camera-ready action** (author's call): either (a) keep Table 3 as diag-best and add one sentence
   in §6.2 — "the single served checkpoint reproduces these cells within 0.1 pp (deployable joint-best,
   `geom_simple` selector)"; or (b) add a joint-best row/column. Numbers for both are here.
-- **What must travel with these numbers:** always name the convention; the CA/TX cells are seed-0 provisional
-  (T6, blocked on A1 n=20); the Istanbul region superiority stat wants a joint-best re-run (T7); AL/AZ region are
-  *matches*, never beats.
+- **What must travel with these numbers:** always name the convention; the CA/TX cells here are the seed-0
+  ×5f joint-best re-score (the n=20 *joint-best* pass is T6, CPU-only and still pending — but A1, the GPU top-up,
+  is done 2026-07-11 and the n=20 diag-best confirms these seed-0 values within <0.13 pp); the Istanbul region
+  superiority stat wants a joint-best re-run (T7); AL/AZ region are *matches*, never beats.
 
 ## Files
 - `data/j1_results.json` — per-run + per-cell machine-readable results (incl. per-fold arrays, epochs, audits).

--- a/docs/studies/closing_data_v2/JOINT_BEST_RESULTS.md
+++ b/docs/studies/closing_data_v2/JOINT_BEST_RESULTS.md
@@ -19,11 +19,11 @@ numerically negligible for these well-converged v17 runs (every joint epoch land
 ## The corrected table (diag-best vs joint-best, side by side)
 
 Category = macro-F1, region = Acc@10 (FULL = top10_acc_indist·(1−ood_frac)). "Dedicated" = the n=20 best-vs-best
-single-task ceiling (`CEILINGS_N20_FINAL.md`, unchanged). n=20 = 4 seeds {0,1,7,100}×5f (± cross-seed sd);
-CA/TX = seed-0 ×5f (± fold sd) for this joint-best re-score — the n=20 *joint-best* pass is task T6 (CPU, now
-unblocked: **A1, the CA/TX v17 MTL n=20 GPU top-up, completed 2026-07-11 on the A40**; the n=20 diag-best confirms
-these seed-0 values within <0.13 pp — CA cat 77.052 / reg 65.693, TX cat 77.239 / reg 67.062,
-`docs/results/closing_data/catx_v17_n20/`).
+single-task ceiling (`CEILINGS_N20_FINAL.md`, unchanged). n=20 = 4 seeds {0,1,7,100}×5f (± cross-seed sd).
+✅ **CA/TX are now n=20 joint-best too — task T6 DONE 2026-07-13** (`score_joint_best.py` on the 8 A1/seed-0
+rundirs → `joint_best_score.json` sidecars). The joint-best ≈ diag-best (Δ joint−diag ≤ 0.006 pp: CA cat −0.006 /
+reg −0.003, TX cat −0.000 / reg −0.003), so **no cell moved** and every CA/TX verdict (beats cat + reg) holds at
+the single-checkpoint joint-best. A1 (the GPU n=20 top-up) completed 2026-07-11 on the A40.
 
 ### Next-category (macro-F1)
 | Dataset | Regions | Dedicated | Joint **diag-best** | Joint **joint-best (deploy)** | Δdeploy−diag |
@@ -32,8 +32,8 @@ these seed-0 values within <0.13 pp — CA cat 77.052 / reg 65.693, TX cat 77.23
 | AL | 1,109 | 56.82 | 64.54 ±0.10 | **64.51 ±0.09** | −0.04 |
 | AZ | 1,547 | 56.43 | 65.84 ±0.02 | **65.79 ±0.02** | −0.05 |
 | FL | 4,703 | 74.51 | 79.85 ±0.03 | **79.84 ±0.02** | −0.01 |
-| TX | 6,553 | 69.79 | 77.23 ±0.12 | **77.23 ±0.12** | −0.00 |
-| CA | 8,501 | 70.60 | 77.04 ±0.20 | **77.04 ±0.20** | −0.00 |
+| TX | 6,553 | 69.79 | 77.239 ±0.014 | **77.239 ±0.013** | −0.00 |
+| CA | 8,501 | 70.60 | 77.052 ±0.006 | **77.046 ±0.005** | −0.01 |
 
 ### Next-region (Acc@10)
 | Dataset | Regions | Dedicated | Joint **diag-best** | Joint **joint-best (deploy)** | Δdeploy−diag |
@@ -42,8 +42,8 @@ these seed-0 values within <0.13 pp — CA cat 77.052 / reg 65.693, TX cat 77.23
 | AL | 1,109 | 70.11 | 69.80 ±0.05 | **69.70 ±0.09** | −0.11 |
 | AZ | 1,547 | 59.46 | 59.56 ±0.05 | **59.46 ±0.04** | −0.11 |
 | FL | 4,703 | 76.70 | 77.42 ±0.03 | **77.41 ±0.02** | −0.01 |
-| TX | 6,553 | 64.95 | 67.07 ±0.45 | **67.07 ±0.45** | −0.00 |
-| CA | 8,501 | 63.49 | 65.69 ±0.30 | **65.69 ±0.30** | −0.01 |
+| TX | 6,553 | 64.95 | 67.062 ±0.007 | **67.059 ±0.008** | −0.00 |
+| CA | 8,501 | 63.49 | 65.693 ±0.017 | **65.690 ±0.019** | −0.00 |
 
 ## Δ vs the dedicated ceiling — does the verdict change?
 
@@ -53,8 +53,8 @@ these seed-0 values within <0.13 pp — CA cat 77.052 / reg 65.693, TX cat 77.23
 | AL | +7.72 | **+7.69** | beats | −0.31 | **−0.41** | matches (≪2 pp) |
 | AZ | +9.40 † | **+9.35** | beats | +0.10 | **−0.00** | matches |
 | FL | +5.34 | **+5.33** | beats | +0.72 | **+0.71** | beats |
-| TX | +7.44 | **+7.44** | beats | +2.12 | **+2.12** | beats |
-| CA | +6.44 | **+6.44** | beats | +2.20 | **+2.20** | beats |
+| TX | +7.45 | **+7.45** | beats | +2.11 | **+2.11** | beats |
+| CA | +6.45 | **+6.45** | beats | +2.20 | **+2.20** | beats |
 
 † AZ diag Δcat: **+9.40** is the paper/board value (from the rounded 65.83 MTL cell, `CEILINGS_N20_FINAL.md`);
 the full-precision Δ from these cells (65.835 − 56.43) is **+9.41**, which is what `score_all.py` / `j1_results.json`

--- a/docs/studies/closing_data_v2/TASKS.md
+++ b/docs/studies/closing_data_v2/TASKS.md
@@ -48,8 +48,10 @@ checkpoint "was not re-scored … can be provided on request; do NOT claim they 
   AL region tail-risk, Istanbul/FL region-margin sensitivity, completeness critic. → `AUDIT.md`.
 - [x] **T5 — Corrected table + decision memo.** Side-by-side diag-best vs joint-best, Δ vs ceilings under both
   conventions, does any verdict change? → `JOINT_BEST_RESULTS.md`.
-- [ ] **T6 (deferred, GPU) — CA/TX joint-best at n=20.** Blocked on **A1** (CA/TX v17 MTL n=20, seeds {1,7,100});
-  the top-up is incomplete on disk. When A1 lands, re-run T2 on the CA/TX n=20 rundirs and drop "provisional".
+- [ ] **T6 (deferred, now CPU-only) — CA/TX joint-best at n=20.** **A1 (CA/TX v17 MTL n=20, seeds {1,7,100}) is
+  DONE — completed 2026-07-11 on the A40** (`docs/results/closing_data/catx_v17_n20/`; the n=20 diag-best confirms
+  the seed-0 cells within <0.13 pp). The GPU top-up it was blocked on is finished; T6's remaining step is now the
+  CPU-only re-run of T2 (`score_joint_best.py`) on the CA/TX n=20 rundirs → then drop "provisional".
 - [ ] **T7 (deferred, CPU) — camera-ready stats on joint-best per-fold pairs.** The paper's region-superiority
   (Wilcoxon 90% CI) + AL/AZ non-inferiority (TOST) were run on diag-best per-fold pairs. For the camera-ready
   joint-best row, re-run `superiority_wilcoxon.py` / `region_match_tost.py` on the joint-best per-fold series.

--- a/docs/studies/closing_data_v2/TASKS.md
+++ b/docs/studies/closing_data_v2/TASKS.md
@@ -48,10 +48,10 @@ checkpoint "was not re-scored … can be provided on request; do NOT claim they 
   AL region tail-risk, Istanbul/FL region-margin sensitivity, completeness critic. → `AUDIT.md`.
 - [x] **T5 — Corrected table + decision memo.** Side-by-side diag-best vs joint-best, Δ vs ceilings under both
   conventions, does any verdict change? → `JOINT_BEST_RESULTS.md`.
-- [ ] **T6 (deferred, now CPU-only) — CA/TX joint-best at n=20.** **A1 (CA/TX v17 MTL n=20, seeds {1,7,100}) is
-  DONE — completed 2026-07-11 on the A40** (`docs/results/closing_data/catx_v17_n20/`; the n=20 diag-best confirms
-  the seed-0 cells within <0.13 pp). The GPU top-up it was blocked on is finished; T6's remaining step is now the
-  CPU-only re-run of T2 (`score_joint_best.py`) on the CA/TX n=20 rundirs → then drop "provisional".
+- [x] **T6 — CA/TX joint-best at n=20. ✅ DONE 2026-07-13.** A1 (the GPU n=20 top-up) completed 2026-07-11;
+  ran `score_joint_best.py` on the 8 CA/TX {0,1,7,100} rundirs → `joint_best_score.json` sidecars, aggregated to
+  n=20. **Joint-best ≈ diag-best (Δ ≤ 0.006 pp)** → JOINT_BEST_RESULTS.md cat/reg/Δ cells refreshed to n=20; no
+  cell moved, every CA/TX beats-verdict holds at the single-checkpoint joint-best. "provisional" dropped.
 - [ ] **T7 (deferred, CPU) — camera-ready stats on joint-best per-fold pairs.** The paper's region-superiority
   (Wilcoxon 90% CI) + AL/AZ non-inferiority (TOST) were run on diag-best per-fold pairs. For the camera-ready
   joint-best row, re-run `superiority_wilcoxon.py` / `region_match_tost.py` on the joint-best per-fold series.


### PR DESCRIPTION
## Summary
**A1 (CA/TX v17 MTL n=20, seeds {1,7,100}) is complete** — the last verdict-changer. The v17 board is now **fully n=20 at all six datasets**, and both downstream CPU stats runs (M1-full, T6 joint-best) are done. **No verdict changed** — the n=20 confirms the seed-0 values with tight variance.

## A1 — the n=20 result
Ran on the A40 via `a1_catx/run_a1_catx_n20.sh` (1-wide fp32, RAM-gated ≥80 GB, resumable per-cell, 2× retry — TX s100 auto-recovered a transient rc=132 crash). A midnight-BRT auto-relaunch restarted it on a freed GPU; a 2-wide smoke proved 2-wide fits RAM but is GPU-bound (no benefit → stayed 1-wide).

| | cat macro-F1 | reg FULL top10 | Δcat | Δreg |
|---|---|---|---|---|
| **CA** | 77.052 ±0.006 | 65.693 ±0.017 | **+6.45** ✅ | **+2.20** ✅ |
| **TX** | 77.239 ±0.014 | 67.062 ±0.007 | **+7.45** ✅ | **+2.11** ✅ |

Per-cell scores: `docs/results/closing_data/catx_v17_n20/`.

## Board fold-in (doc updates)
- **CEILINGS_N20_FINAL**: CA/TX → n=20, **seed-0 asterisks dropped**, "all states n=20 / board complete."
- **RESULTS_BOARD §1**: v17 CA/TX → n=20, "pending" note → DONE.
- **catx_v17_seed0_5f/RESULTS.md**, **v17_completion/{README,A40}.md**: A1 → DONE.
- Active-doc sweep (closing_data_v2, JOINT_BEST_SCORING, M2PRO, log.md); 9 unrelated docs correctly skipped.

## M1-full (6-dataset pre-registered Holm)
`m1_stats_n20.py` §5 appended (`m1_full_output.txt`): CA/TX join the seed-level family at n=20. All artifact→board gates pass. **The 6-dataset cat-superiority family Holm ALL REJECT @ α=0.05** (every Holm-adj p ≤ 8.9e-07) — MTL beats the category ceiling at every dataset. Reg beats at FL/CA/TX/Istanbul (CA reg Δ+2.20, 90% CI +2.193…+2.215). The M1-PARTIAL/PROVISIONAL banners lift.

## T6 joint-best re-score
`score_joint_best.py` on the 8 CA/TX {0,1,7,100} rundirs (sidecars in `catx_v17_n20/joint_best/`): joint-best n=20 = CA 77.046/65.690, TX 77.239/67.059 — **≈ diag-best (Δ ≤ 0.006 pp)**. JOINT_BEST_RESULTS cells refreshed; every CA/TX beats-verdict holds at the single-checkpoint joint-best too.

## Net
Every v17 board cell is n=20; the "MTL beats both STL ceilings" story holds at full n=20 with the pre-registered 6-dataset Holm passing. Also includes (earlier in the branch) the ReHDM faithful-v4 baselines + Istanbul FSQ→mahalle adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)